### PR TITLE
Generalize sending using EmailContent & EmailRecipients with lists

### DIFF
--- a/email/include/email/curl_context.hpp
+++ b/email/include/email/curl_context.hpp
@@ -27,9 +27,9 @@ class CurlContext
 {
 public:
   explicit CurlContext(
-    struct email::UserInfo user_info,
-    struct email::ProtocolInfo protocol_info,
-    bool debug);
+    const struct email::UserInfo & user_info,
+    const struct email::ProtocolInfo & protocol_info,
+    const bool debug);
   CurlContext(const CurlContext &) = delete;
   virtual ~CurlContext();
 
@@ -49,7 +49,7 @@ public:
     return full_url_;
   }
 
-  struct email::UserInfo & get_user_info()
+  const struct email::UserInfo & get_user_info()
   {
     return user_info_;
   }
@@ -60,8 +60,8 @@ private:
   //   std::optional<std::string> custom_request) = 0;
 
   CURL * handle_;
-  struct email::UserInfo user_info_;
-  struct email::ProtocolInfo protocol_info_;
+  const struct email::UserInfo user_info_;
+  const struct email::ProtocolInfo protocol_info_;
   std::string full_url_;
   bool debug_;
 };

--- a/email/include/email/curl_executor.hpp
+++ b/email/include/email/curl_executor.hpp
@@ -28,9 +28,9 @@ public:
 
 protected:
   explicit CurlExecutor(
-    struct email::UserInfo user_info,
-    struct email::ProtocolInfo protocol_info,
-    bool debug);
+    const struct email::UserInfo & user_info,
+    const struct email::ProtocolInfo & protocol_info,
+    const bool debug);
   CurlExecutor(const CurlExecutor &) = delete;
   virtual ~CurlExecutor();
 
@@ -39,7 +39,7 @@ protected:
   bool is_valid() const;
 
   CurlContext context_;
-  bool debug_;
+  const bool debug_;
 
 private:
   bool is_valid_;

--- a/email/include/email/email_receiver.hpp
+++ b/email/include/email/email_receiver.hpp
@@ -29,8 +29,8 @@ class EmailReceiver : public CurlExecutor
 {
 public:
   explicit EmailReceiver(
-    struct email::UserInfo user_info,
-    bool debug = true);
+    const struct email::UserInfo & user_info,
+    const bool debug = true);
   EmailReceiver(const EmailReceiver &) = delete;
   virtual ~EmailReceiver();
 

--- a/email/include/email/email_sender.hpp
+++ b/email/include/email/email_sender.hpp
@@ -16,6 +16,7 @@
 #define EMAIL__EMAIL_SENDER_HPP_
 
 #include <string>
+#include <vector>
 
 #include "email/curl_executor.hpp"
 #include "email/types.hpp"
@@ -34,28 +35,27 @@ class EmailSender : public CurlExecutor
 {
 public:
   explicit EmailSender(
-    struct email::UserInfo user_info,
-    const std::string & to,
-    bool debug = true);
+    const struct email::UserInfo & user_info,
+    const struct email::EmailRecipients & recipients,
+    const bool debug = true);
   EmailSender(const EmailSender &) = delete;
   virtual ~EmailSender();
 
-  bool send(
-    const std::string & subject,
-    const std::string & body);
+  bool send(const struct email::EmailContent & content);
 
 protected:
   virtual bool init_options();
 
 private:
-  static std::string build_payload(
-    const std::string & to,
-    const std::string & subject,
-    const std::string & body);
+  static const std::string build_payload(
+    const struct email::EmailRecipients & recipients,
+    const struct email::EmailContent & content);
+  static const std::string join_list(
+    const std::vector<std::string> & list);
 
-  struct curl_slist * recipients_;
+  const struct email::EmailRecipients recipients_;
+  struct curl_slist * recipients_list_;
   struct UploadData upload_ctx_;
-  const std::string email_to_;
 };
 
 // }  // namespace email

--- a/email/include/email/types.hpp
+++ b/email/include/email/types.hpp
@@ -16,6 +16,7 @@
 #define EMAIL__TYPES_HPP_
 
 #include <string>
+#include <vector>
 
 namespace email
 {
@@ -37,6 +38,29 @@ struct ProtocolInfo
   // Port
   int port;
 };
+
+struct EmailRecipients
+{
+  std::vector<std::string> to;
+  std::vector<std::string> cc;
+  std::vector<std::string> bcc;
+};
+
+struct EmailContent
+{
+  // Subject, which should be one line without any newlines
+  std::string subject;
+  // Body/content, which may have multiple lines
+  std::string body;
+};
+
+// struct Email
+// {
+//   // Recipients of the email
+//   struct EmailRecipients recipients;
+//   // Content of the email
+//   struct EmailContent content;
+// };
 
 }  // namespace email
 

--- a/email/src/curl_context.cpp
+++ b/email/src/curl_context.cpp
@@ -22,10 +22,11 @@
 #include "email/types.hpp"
 
 CurlContext::CurlContext(
-  struct email::UserInfo user_info,
-  struct email::ProtocolInfo protocol_info,
-  bool debug)
-: user_info_(user_info),
+  const struct email::UserInfo & user_info,
+  const struct email::ProtocolInfo & protocol_info,
+  const bool debug)
+: handle_(nullptr),
+  user_info_(user_info),
   protocol_info_(protocol_info),
   debug_(debug)
 {

--- a/email/src/curl_executor.cpp
+++ b/email/src/curl_executor.cpp
@@ -16,9 +16,9 @@
 #include "email/types.hpp"
 
 CurlExecutor::CurlExecutor(
-  struct email::UserInfo user_info,
-  struct email::ProtocolInfo protocol_info,
-  bool debug)
+  const struct email::UserInfo & user_info,
+  const struct email::ProtocolInfo & protocol_info,
+  const bool debug)
 : context_(user_info, protocol_info, debug),
   debug_(debug),
   is_valid_(false)

--- a/email/src/email_receiver.cpp
+++ b/email/src/email_receiver.cpp
@@ -34,8 +34,8 @@ static size_t write_callback(void * contents, size_t size, size_t nmemb, void * 
 }
 
 EmailReceiver::EmailReceiver(
-  struct email::UserInfo user_info,
-  bool debug)
+  const struct email::UserInfo & user_info,
+  const bool debug)
 : CurlExecutor(user_info, {"imaps", 993}, debug),
   read_buffer_()
 {}

--- a/email/src/send.cpp
+++ b/email/src/send.cpp
@@ -24,16 +24,14 @@ int main(int argc, char ** argv)
   if (!info_opt) {
     return 1;
   }
-  struct email::UserInfo info = info_opt.value();
-  const std::string to = "bedard.christophe@gmail.com";
-  EmailSender sender(info, to);
+  const struct email::UserInfo info = info_opt.value();
+  const struct email::EmailRecipients recipients = {{"bedard.christophe@gmail.com"}, {}, {}};
+  EmailSender sender(info, recipients);
   if (!sender.init()) {
     return 1;
   }
   const std::string subject = "this is the subject";
   const std::string body = "this is the body!";
-  bool ret = sender.send(
-    subject,
-    body);
+  bool ret = sender.send({subject, body});
   return ret ? 0 : 1;
 }


### PR DESCRIPTION
This adds a new EmailRecipients struct to generalize sending for to/cc/bcc lists instead of only having one "to" recipient.

This also adds an EmailContent struct.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>