### PR TITLE
Cut subject string if it contains newline characters

### DIFF
--- a/email/include/email/payload_utils.hpp
+++ b/email/include/email/payload_utils.hpp
@@ -15,6 +15,7 @@
 #ifndef EMAIL__PAYLOAD_UTILS_HPP_
 #define EMAIL__PAYLOAD_UTILS_HPP_
 
+#include <regex>
 #include <string>
 #include <vector>
 
@@ -44,6 +45,11 @@ public:
 
   static const std::string join_list(
     const std::vector<std::string> & list);
+
+  static std::string cut_string_if_newline(const std::string & string);
+
+private:
+  static const std::regex regex_newline;
 };
 
 }  // namespace utils

--- a/email/src/send.cpp
+++ b/email/src/send.cpp
@@ -30,8 +30,8 @@ int main(int argc, char ** argv)
   if (!sender.init()) {
     return 1;
   }
-  const std::string subject = "this is the subject";
-  const std::string body = "this is the body!";
+  const std::string subject = "this is the subject\nwoopsies";
+  const std::string body = "this is the body!\nthis is on another line";
   bool ret = sender.send({subject, body});
   return ret ? 0 : 1;
 }


### PR DESCRIPTION
This adds a util function that cuts a string starting from a newline character if it contains one (e.g. `\r` and/or `\n`). This is used to cut subject strings if necessary.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>