### PR TITLE
Extract email content from curl string response and return struct

### DIFF
--- a/email/include/email/email_receiver.hpp
+++ b/email/include/email/email_receiver.hpp
@@ -37,24 +37,32 @@ public:
   EmailReceiver(const EmailReceiver &) = delete;
   virtual ~EmailReceiver();
 
-  std::optional<std::string> get_email();
+  std::optional<struct EmailContent> get_email();
 
 protected:
   virtual bool init_options();
 
 private:
-  virtual std::optional<std::string> execute(
+  std::optional<std::string> execute(
     std::optional<std::string> url_options,
     std::optional<std::string> custom_request);
 
   std::optional<int> get_nextuid_from_response(const std::string & response);
   std::optional<int> get_nextuid();
 
-  std::optional<std::string> get_email_from_uid(int uid);
+  std::optional<struct EmailContent> get_email_from_uid(int uid);
+
+  std::optional<struct EmailContent> result_to_email_content(const std::string & curl_result);
+
+  std::optional<std::string> get_first_match_group(
+    const std::string & string,
+    const std::regex & regex);
 
   std::string read_buffer_;
 
   static const std::regex regex_nextuid;
+  static const std::regex regex_subject;
+  static const std::regex regex_body;
 };
 
 }  // namespace email

--- a/email/src/receive.cpp
+++ b/email/src/receive.cpp
@@ -31,10 +31,12 @@ int main(int argc, char ** argv)
   if (!receiver.init()) {
     return 1;
   }
-  std::optional<std::string> response = receiver.get_email();
+  std::optional<struct email::EmailContent> response = receiver.get_email();
   if (!response) {
     return 1;
   }
-  std::cout << "response!" << std::endl << response.value() << std::endl;
+  std::cout << "response!" << std::endl <<
+    response.value().subject << std::endl << std::endl <<
+    response.value().body << std::endl;
   return 0;
 }


### PR DESCRIPTION
Instead of simply returning the response string for get_email(), this uses regexes to extract the email's subject and body and returns an EmailContent struct.

This also switches to raw strings for the regexes.