### PR TITLE
Allow passing options via a .yml file with path through an env var

### DIFF
--- a/email/CMakeLists.txt
+++ b/email/CMakeLists.txt
@@ -14,6 +14,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 endif()
 
 find_package(ament_cmake_ros REQUIRED)
+find_package(rcpputils REQUIRED)
 
 set(CURL_USE_VENDOR FALSE)
 find_package(CURL)
@@ -48,6 +49,7 @@ if(CURL_USE_VENDOR)
 else()
   target_link_libraries(${PROJECT_NAME} ${CURL_LIBRARIES})
 endif()
+ament_target_dependencies(${PROJECT_NAME} rcpputils)
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>"

--- a/email/include/email/context.hpp
+++ b/email/include/email/context.hpp
@@ -40,7 +40,8 @@ public:
   Context(const Context &) = delete;
   ~Context();
 
-  // void init();
+  void init();
+
   void init(int argc, char const * const argv[]);
 
   bool shutdown();

--- a/email/include/email/init.hpp
+++ b/email/include/email/init.hpp
@@ -20,7 +20,8 @@
 namespace email
 {
 
-// void init();
+void init();
+
 void init(int argc, char const * const argv[]);
 
 bool shutdown();

--- a/email/include/email/options.hpp
+++ b/email/include/email/options.hpp
@@ -17,6 +17,8 @@
 
 #include <memory>
 #include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
+#include <regex>
+#include <string>
 
 #include "email/types.hpp"
 
@@ -36,13 +38,23 @@ public:
   std::optional<std::shared_ptr<struct EmailRecipients>> get_recipients() const;
   bool debug() const;
 
+  static
+  std::optional<std::shared_ptr<Options>>
+  parse_options_from_args(int argc, char const * const argv[]);
+
+  static
+  std::optional<std::shared_ptr<Options>>
+  parse_options_from_file();
+
 private:
   std::shared_ptr<struct UserInfo> user_info_;
   std::optional<std::shared_ptr<struct EmailRecipients>> recipients_;
   bool debug_;
-};
 
-std::optional<std::shared_ptr<Options>> parse_options(int argc, char const * const argv[]);
+  static const std::regex regex_params_file;
+  static constexpr const char * env_var_debug = "EMAIL_DEBUG";
+  static constexpr const char * env_var_options_file = "EMAIL_OPTIONS_FILE";
+};
 
 }  // namespace email
 

--- a/email/include/email/utils.hpp
+++ b/email/include/email/utils.hpp
@@ -16,6 +16,7 @@
 #define EMAIL__UTILS_HPP_
 
 #include <memory>
+#include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
 #include <stdexcept>
 #include <string>
 
@@ -36,6 +37,7 @@ std::string string_format(const std::string & format, Args... args)
   return std::string(buf.get(), buf.get() + size - 1);
 }
 
+std::optional<std::string> read_file(const std::string & path);
 
 }  // namespace utils
 }  // namespace email

--- a/email/package.xml
+++ b/email/package.xml
@@ -18,6 +18,7 @@
 
   <!-- Only actually used if libcurl isn't found on the system -->
   <depend>libcurl_vendor</depend>
+  <depend>rcpputils</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/email/src/context.cpp
+++ b/email/src/context.cpp
@@ -36,13 +36,25 @@ Context::Context()
 Context::~Context()
 {}
 
+void Context::init()
+{
+  if (is_valid_) {
+    throw std::runtime_error("Context already initialized");
+  }
+  auto options = Options::parse_options_from_file();
+  if (!options) {
+    throw std::runtime_error("Context::init() failed");
+  }
+  options_ = options.value();
+  is_valid_ = true;
+}
+
 void Context::init(int argc, char const * const argv[])
 {
   if (is_valid_) {
     throw std::runtime_error("Context already initialized");
   }
-  // TODO(christophebedard) get recipients from argc/argv
-  auto options = parse_options(argc, argv);
+  auto options = Options::parse_options_from_args(argc, argv);
   if (!options) {
     throw std::runtime_error("Context::init() failed");
   }

--- a/email/src/example/pub.cpp
+++ b/email/src/example/pub.cpp
@@ -13,14 +13,13 @@
 // limitations under the License.
 
 #include <iostream>
-#include <string>
 
 #include "email/init.hpp"
 #include "email/publisher.hpp"
 
-int main(int argc, char ** argv)
+int main()
 {
-  email::init(argc, argv);
+  email::init();
   email::Publisher pub("/my_topic");
   std::cout << "publishing message" << std::endl;
   pub.publish("my awesome message!");

--- a/email/src/example/receive.cpp
+++ b/email/src/example/receive.cpp
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 #include <iostream>
+#include <memory>
 #include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
-#include <string>
 
+#include "email/context.hpp"
 #include "email/email/receiver.hpp"
 #include "email/init.hpp"
 #include "email/options.hpp"
@@ -24,12 +25,8 @@
 int main(int argc, char ** argv)
 {
   email::init(argc, argv);
-  auto options = email::parse_options(argc, argv);
-  if (!options) {
-    return 1;
-  }
-  const struct email::UserInfo info = *options.value()->get_user_info().get();
-  email::EmailReceiver receiver(info);
+  std::shared_ptr<email::Options> options = email::get_global_context()->get_options();
+  email::EmailReceiver receiver(*options->get_user_info().get());
   if (!receiver.init()) {
     return 1;
   }

--- a/email/src/example/send.cpp
+++ b/email/src/example/send.cpp
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
 #include <string>
 
+#include "email/context.hpp"
 #include "email/email/sender.hpp"
 #include "email/init.hpp"
 #include "email/types.hpp"
@@ -22,13 +24,13 @@
 int main(int argc, char ** argv)
 {
   email::init(argc, argv);
-  auto options = email::parse_options(argc, argv);
-  if (!options || !options.value()->get_recipients().has_value()) {
+  std::shared_ptr<email::Options> options = email::get_global_context()->get_options();
+  if (!options->get_recipients().has_value()) {
     return 1;
   }
-  const struct email::UserInfo info = *options.value()->get_user_info().get();
-  const struct email::EmailRecipients recipients = *options.value()->get_recipients().value().get();
-  email::EmailSender sender(info, recipients);
+  email::EmailSender sender(
+    *options->get_user_info().get(),
+    *options->get_recipients().value().get());
   if (!sender.init()) {
     return 1;
   }

--- a/email/src/example/sub.cpp
+++ b/email/src/example/sub.cpp
@@ -13,17 +13,15 @@
 // limitations under the License.
 
 #include <iostream>
-#include <string>
 
 #include "email/init.hpp"
 #include "email/subscriber.hpp"
 
-int main(int argc, char ** argv)
+int main()
 {
-  email::init(argc, argv);
+  email::init();
   email::Subscriber sub("/my_topic");
   std::cout << "getting message..." << std::endl;
-  const std::string message = sub.get_message();
-  std::cout << "got message: " << message << std::endl;
+  std::cout << "got message: " << sub.get_message() << std::endl;
   return 0;
 }

--- a/email/src/init.cpp
+++ b/email/src/init.cpp
@@ -18,6 +18,11 @@
 namespace email
 {
 
+void init()
+{
+  get_global_context()->init();
+}
+
 void init(int argc, char const * const argv[])
 {
   get_global_context()->init(argc, argv);

--- a/email/src/utils.cpp
+++ b/email/src/utils.cpp
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <fstream>
+#include <sstream>
+#include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
+#include <string>
+
 #include "email/utils.hpp"
 
 namespace email
@@ -19,7 +24,14 @@ namespace email
 namespace utils
 {
 
-// TODO(christophebedard) remove if unused
+std::optional<std::string> read_file(const std::string & path)
+{
+  // TODO(christophebedard) handle possible failure
+  std::ifstream stream(path);
+  std::stringstream buffer;
+  buffer << stream.rdbuf();
+  return buffer.str();
+}
 
 }  // namespace utils
 }  // namespace email


### PR DESCRIPTION
This way the call to email::init needs no parameters. This makes it a bit simpler and also makes integrating with other thing easier.

The path to the options file should be set in the `EMAIL_OPTIONS_FILE` env var, and is relative tom the current working directory.

Additionally, users can set `EMAIL_DEBUG` (to anything) to enable debug outputs.

Refactoring/cleanup will be done in a follow-up PR.

Closes #16