### PR TITLE
Move curl read/write functions to classes and cleanup

### DIFF
--- a/email/include/email/context.hpp
+++ b/email/include/email/context.hpp
@@ -28,11 +28,6 @@
 namespace email
 {
 
-// void init();
-void init(int argc, char const * const argv[]);
-
-bool shutdown();
-
 class Context
 {
 public:

--- a/email/include/email/email/receiver.hpp
+++ b/email/include/email/email/receiver.hpp
@@ -50,6 +50,8 @@ private:
 
   std::optional<struct EmailContent> get_email_from_uid(int uid);
 
+  static size_t write_callback(void * contents, size_t size, size_t nmemb, void * userp);
+
   std::string read_buffer_;
 };
 

--- a/email/include/email/email/sender.hpp
+++ b/email/include/email/email/sender.hpp
@@ -25,12 +25,6 @@
 namespace email
 {
 
-struct UploadData
-{
-  const char * payload;
-  int lines_read;
-};
-
 class EmailSender : public CurlExecutor
 {
 public:
@@ -46,6 +40,14 @@ protected:
   virtual bool init_options();
 
 private:
+  static size_t read_payload_callback(void * ptr, size_t size, size_t nmemb, void * userp);
+
+  struct UploadData
+  {
+    const char * payload;
+    int lines_read;
+  };
+
   const struct EmailRecipients recipients_;
   struct curl_slist * recipients_list_;
   struct UploadData upload_ctx_;

--- a/email/include/email/utils.hpp
+++ b/email/include/email/utils.hpp
@@ -42,6 +42,11 @@ std::optional<std::string> read_file(const std::string & path);
 
 std::vector<std::string> split_email_list(const std::string & list);
 
+std::string full_url(
+  const std::string & protocol,
+  const std::string & host,
+  const int port);
+
 }  // namespace utils
 }  // namespace email
 

--- a/email/src/curl/context.cpp
+++ b/email/src/curl/context.cpp
@@ -20,6 +20,7 @@
 
 #include "email/curl/context.hpp"
 #include "email/types.hpp"
+#include "email/utils.hpp"
 
 namespace email
 {
@@ -33,8 +34,10 @@ CurlContext::CurlContext(
   protocol_info_(protocol_info),
   debug_(debug)
 {
-  full_url_ = protocol_info_.protocol + "://" +
-    user_info_.url + ":" + std::to_string(protocol_info_.port) + "/";
+  full_url_ = utils::full_url(
+    protocol_info_.protocol,
+    user_info_.url,
+    protocol_info_.port);
 }
 CurlContext::~CurlContext() {}
 

--- a/email/src/email/receiver.cpp
+++ b/email/src/email/receiver.cpp
@@ -30,13 +30,6 @@
 namespace email
 {
 
-// TODO(christophebedard) move to class?
-static size_t write_callback(void * contents, size_t size, size_t nmemb, void * userp)
-{
-  (static_cast<std::string *>(userp))->append(static_cast<char *>(contents), size * nmemb);
-  return size * nmemb;
-}
-
 EmailReceiver::EmailReceiver(
   const struct UserInfo & user_info)
 : CurlExecutor(user_info, {"imaps", 993}),
@@ -45,6 +38,12 @@ EmailReceiver::EmailReceiver(
 
 EmailReceiver::~EmailReceiver()
 {}
+
+size_t EmailReceiver::write_callback(void * contents, size_t size, size_t nmemb, void * userp)
+{
+  (static_cast<std::string *>(userp))->append(static_cast<char *>(contents), size * nmemb);
+  return size * nmemb;
+}
 
 bool EmailReceiver::init_options()
 {

--- a/email/src/utils.cpp
+++ b/email/src/utils.cpp
@@ -41,5 +41,13 @@ std::vector<std::string> split_email_list(const std::string & list)
   return rcpputils::split(list, ',', true);
 }
 
+std::string full_url(
+  const std::string & protocol,
+  const std::string & host,
+  const int port)
+{
+  return protocol + "://" + host + ":" + std::to_string(port) + "/";
+}
+
 }  // namespace utils
 }  // namespace email


### PR DESCRIPTION
The curl read/write functions still have to be static, but they can be static class functions.