### PR TITLE
Include both SMTP and IMAP hostnames in config file

### DIFF
--- a/email/include/email/curl/context.hpp
+++ b/email/include/email/curl/context.hpp
@@ -29,7 +29,7 @@ class CurlContext
 {
 public:
   explicit CurlContext(
-    const struct UserInfo & user_info,
+    const struct ConnectionInfo & connection_info,
     const struct ProtocolInfo & protocol_info,
     const bool debug);
   CurlContext(const CurlContext &) = delete;
@@ -41,26 +41,16 @@ public:
 
   bool execute();
 
-  CURL * get_handle()
-  {
-    return handle_;
-  }
+  CURL * get_handle();
 
-  const std::string & get_full_url()
-  {
-    return full_url_;
-  }
+  const std::string & get_full_url() const;
 
-  const struct UserInfo & get_user_info()
-  {
-    return user_info_;
-  }
+  const struct ConnectionInfo & get_connection_info() const;
 
 private:
   CURL * handle_;
-  const struct UserInfo user_info_;
-  const struct ProtocolInfo protocol_info_;
-  std::string full_url_;
+  const struct ConnectionInfo connection_info_;
+  const std::string full_url_;
   bool debug_;
 };
 

--- a/email/include/email/curl/executor.hpp
+++ b/email/include/email/curl/executor.hpp
@@ -30,11 +30,11 @@ public:
 
 protected:
   explicit CurlExecutor(
-    const struct UserInfo & user_info,
+    const struct ConnectionInfo & connection_info,
     const struct ProtocolInfo & protocol_info,
     const bool debug);
   explicit CurlExecutor(
-    const struct UserInfo & user_info,
+    const struct ConnectionInfo & connection_info,
     const struct ProtocolInfo & protocol_info);
   CurlExecutor(const CurlExecutor &) = delete;
   virtual ~CurlExecutor();

--- a/email/include/email/types.hpp
+++ b/email/include/email/types.hpp
@@ -21,16 +21,18 @@
 namespace email
 {
 
-struct UserInfo
+/// Info for connecting to server.
+struct ConnectionInfo
 {
-  // URL without the port or '<protocol>://'
-  std::string url;
+  // Host name without protocol or port
+  std::string host;
   // Username (i.e. email)
   std::string username;
   // Password
   std::string password;
 };
 
+/// Info for a standard protocol.
 struct ProtocolInfo
 {
   // Protocol, i.e. <protocol>://
@@ -39,6 +41,20 @@ struct ProtocolInfo
   int port;
 };
 
+/// Info for a user.
+struct UserInfo
+{
+  // SMTP host, without the port or protocol
+  std::string host_smtp;
+  // IMAP host, without the port or protocol
+  std::string host_imap;
+  // Username (i.e. email)
+  std::string username;
+  // Password
+  std::string password;
+};
+
+/// Recipients of an email.
 struct EmailRecipients
 {
   std::vector<std::string> to;
@@ -46,6 +62,7 @@ struct EmailRecipients
   std::vector<std::string> bcc;
 };
 
+/// Content of an email.
 struct EmailContent
 {
   // Subject, which should be one line without any newlines
@@ -53,14 +70,6 @@ struct EmailContent
   // Body/content, which may have multiple lines
   std::string body;
 };
-
-// struct Email
-// {
-//   // Recipients of the email
-//   struct EmailRecipients recipients;
-//   // Content of the email
-//   struct EmailContent content;
-// };
 
 }  // namespace email
 

--- a/email/src/curl/executor.cpp
+++ b/email/src/curl/executor.cpp
@@ -20,18 +20,18 @@ namespace email
 {
 
 CurlExecutor::CurlExecutor(
-  const struct UserInfo & user_info,
+  const struct ConnectionInfo & connection_info,
   const struct ProtocolInfo & protocol_info,
   const bool debug)
-: context_(user_info, protocol_info, debug),
+: context_(connection_info, protocol_info, debug),
   debug_(debug),
   is_valid_(false)
 {}
 
 CurlExecutor::CurlExecutor(
-  const struct UserInfo & user_info,
+  const struct ConnectionInfo & connection_info,
   const struct ProtocolInfo & protocol_info)
-: CurlExecutor(user_info, protocol_info, get_global_context()->get_options()->debug())
+: CurlExecutor(connection_info, protocol_info, get_global_context()->get_options()->debug())
 {}
 
 CurlExecutor::~CurlExecutor()

--- a/email/src/email/receiver.cpp
+++ b/email/src/email/receiver.cpp
@@ -32,7 +32,9 @@ namespace email
 
 EmailReceiver::EmailReceiver(
   const struct UserInfo & user_info)
-: CurlExecutor(user_info, {"imaps", 993}),
+: CurlExecutor(
+    {user_info.host_imap, user_info.username, user_info.password},
+    {"imaps", 993}),
   read_buffer_()
 {}
 

--- a/email/src/email/sender.cpp
+++ b/email/src/email/sender.cpp
@@ -32,7 +32,9 @@ namespace email
 EmailSender::EmailSender(
   const struct UserInfo & user_info,
   const struct EmailRecipients & recipients)
-: CurlExecutor(user_info, {"smtps", 465}),
+: CurlExecutor(
+    {user_info.host_smtp, user_info.username, user_info.password},
+    {"smtps", 465}),
   recipients_(recipients),
   recipients_list_(nullptr),
   upload_ctx_()
@@ -71,7 +73,7 @@ bool EmailSender::init_options()
   // curl_easy_setopt(context_.get_handle(), CURLOPT_SSL_VERIFYPEER, 0L);
   // curl_easy_setopt(context_.get_handle(), CURLOPT_SSL_VERIFYHOST, 0L);
   curl_easy_setopt(
-    context_.get_handle(), CURLOPT_MAIL_FROM, context_.get_user_info().username.c_str());
+    context_.get_handle(), CURLOPT_MAIL_FROM, context_.get_connection_info().username.c_str());
   // Add all destination emails to the list of recipients
   for (auto & email_to : recipients_.to) {
     recipients_list_ = curl_slist_append(recipients_list_, email_to.c_str());

--- a/email/src/subscriber.cpp
+++ b/email/src/subscriber.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
 #include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
 #include <string>
 
@@ -44,7 +43,6 @@ std::string Subscriber::get_message()
       email = receiver_->get_email();
     }
     subject = email.value().subject;
-    std::cout << "got email with subject: " << subject << std::endl;
   }
   return email.value().body;
 }


### PR DESCRIPTION
This way the same config file can be used for both sending and receiving emails.

However, it is not necessary to actually a value for  `url-imap` if we do not want to receive emails. Same for `url-smtp` and sending emails. This means that we have to check that the one we want to use has
actually been set.

Closes #24