### PR TITLE
Use default config file path if env var is not set

### DIFF
--- a/email/include/email/options.hpp
+++ b/email/include/email/options.hpp
@@ -51,9 +51,10 @@ private:
   std::optional<std::shared_ptr<struct EmailRecipients>> recipients_;
   bool debug_;
 
-  static const std::regex regex_params_file;
-  static constexpr const char * env_var_debug = "EMAIL_DEBUG";
-  static constexpr const char * env_var_options_file = "EMAIL_OPTIONS_FILE";
+  static const std::regex REGEX_CONFIG_FILE;
+  static constexpr const char * ENV_VAR_DEBUG = "EMAIL_DEBUG";
+  static constexpr const char * ENV_VAR_CONFIG_FILE = "EMAIL_CONFIG_FILE";
+  static constexpr const char * ENV_VAR_CONFIG_FILE_DEFAULT = "email.yml";
 };
 
 }  // namespace email

--- a/email/include/email/utils.hpp
+++ b/email/include/email/utils.hpp
@@ -38,6 +38,12 @@ std::string string_format(const std::string & format, Args... args)
   return std::string(buf.get(), buf.get() + size - 1);
 }
 
+std::string get_env_var(const std::string & env_var);
+
+std::string get_env_var_or_default(
+  const std::string & env_var,
+  const std::string & default_value);
+
 std::optional<std::string> read_file(const std::string & path);
 
 std::vector<std::string> split_email_list(const std::string & list);

--- a/email/src/utils.cpp
+++ b/email/src/utils.cpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 
+#include "rcpputils/get_env.hpp"
 #include "rcpputils/split.hpp"
 
 #include "email/utils.hpp"
@@ -26,6 +27,19 @@ namespace email
 {
 namespace utils
 {
+
+std::string get_env_var(const std::string & env_var)
+{
+  return rcpputils::get_env_var(env_var.c_str());
+}
+
+std::string get_env_var_or_default(
+  const std::string & env_var,
+  const std::string & default_value)
+{
+  const std::string value = rcpputils::get_env_var(env_var.c_str());
+  return !value.empty() ? value : default_value;
+}
 
 std::optional<std::string> read_file(const std::string & path)
 {


### PR DESCRIPTION
This uses a default path (`email.yml` wrt cwd) if the env var is not set. Additionally, this changes "options file" to "config file" in some places.

Also, this makes some constant variable names uppercase.

Closes #26