### PR TITLE
Make email recipients info mandatory

### DIFF
--- a/email/include/email/options.hpp
+++ b/email/include/email/options.hpp
@@ -42,7 +42,7 @@ public:
    */
   Options(
     std::shared_ptr<struct UserInfo> user_info,
-    std::optional<std::shared_ptr<struct EmailRecipients>> recipients,
+    std::shared_ptr<struct EmailRecipients> recipients,
     bool debug);
   ~Options();
 
@@ -57,7 +57,7 @@ public:
   /**
    * \return the `EmailRecipients` object
    */
-  std::optional<std::shared_ptr<struct EmailRecipients>>
+  std::shared_ptr<struct EmailRecipients>
   get_recipients() const;
 
   /// Get the debug status.
@@ -87,13 +87,15 @@ public:
 
 private:
   std::shared_ptr<struct UserInfo> user_info_;
-  std::optional<std::shared_ptr<struct EmailRecipients>> recipients_;
+  std::shared_ptr<struct EmailRecipients> recipients_;
   bool debug_;
 
   static const std::regex REGEX_CONFIG_FILE;
   static constexpr const char * ENV_VAR_DEBUG = "EMAIL_DEBUG";
   static constexpr const char * ENV_VAR_CONFIG_FILE = "EMAIL_CONFIG_FILE";
   static constexpr const char * ENV_VAR_CONFIG_FILE_DEFAULT = "email.yml";
+  static constexpr const char * USAGE_CLI_ARGS =
+    "usage: --user HOST_SMTP HOST_IMAP EMAIL PASSWORD --recipient TO [-d|--debug]";
 };
 
 }  // namespace email

--- a/email/src/context.cpp
+++ b/email/src/context.cpp
@@ -115,13 +115,10 @@ Context::get_sender() const
   if (!is_valid_) {
     throw std::runtime_error("Context not initialized");
   }
-  if (!options_->get_recipients().has_value()) {
-    throw std::runtime_error("no recipients");
-  }
   // TODO(christophebedard) have classes use the shared_ptrs
   static std::shared_ptr<EmailSender> sender = std::make_shared<EmailSender>(
     *options_->get_user_info().get(),
-    *options_->get_recipients().value().get());
+    *options_->get_recipients().get());
   if (!sender->is_valid()) {
     sender->init();
   }

--- a/email/src/example/send.cpp
+++ b/email/src/example/send.cpp
@@ -25,12 +25,9 @@ int main(int argc, char ** argv)
 {
   email::init(argc, argv);
   std::shared_ptr<email::Options> options = email::get_global_context()->get_options();
-  if (!options->get_recipients().has_value()) {
-    return 1;
-  }
   email::EmailSender sender(
     *options->get_user_info().get(),
-    *options->get_recipients().value().get());
+    *options->get_recipients().get());
   if (!sender.init()) {
     return 1;
   }


### PR DESCRIPTION
This removes the need for extra checks.

For config files, which should be the way users provide options, the recipients data was already "mandatory" even if it could simply be empty.