### PR TITLE
Pass debug flag directly from object creations in context

### DIFF
--- a/email/include/email/curl/executor.hpp
+++ b/email/include/email/curl/executor.hpp
@@ -53,10 +53,6 @@ protected:
     const struct ConnectionInfo & connection_info,
     const struct ProtocolInfo & protocol_info,
     const bool debug);
-  // TODO(christophebedard) remove and use the one with debug instead
-  explicit CurlExecutor(
-    const struct ConnectionInfo & connection_info,
-    const struct ProtocolInfo & protocol_info);
   CurlExecutor(const CurlExecutor &) = delete;
   virtual ~CurlExecutor();
 

--- a/email/include/email/email/receiver.hpp
+++ b/email/include/email/email/receiver.hpp
@@ -37,9 +37,10 @@ class EmailReceiver : public CurlExecutor
 public:
   /// Constructor.
   /**
-   * \param user_info the user information
+   * \param user_info the user information for receiving emails
+   * \param debug the debug status
    */
-  explicit EmailReceiver(const struct UserInfo & user_info);
+  explicit EmailReceiver(const struct UserInfo & user_info, const bool debug);
   EmailReceiver(const EmailReceiver &) = delete;
   virtual ~EmailReceiver();
 

--- a/email/include/email/email/sender.hpp
+++ b/email/include/email/email/sender.hpp
@@ -34,9 +34,16 @@ namespace email
 class EmailSender : public CurlExecutor
 {
 public:
+  /// Constructor.
+  /**
+   * \param user_info the user information for sending emails
+   * \param recipients the email recipients
+   * \param debug the debug status
+   */
   explicit EmailSender(
     const struct UserInfo & user_info,
-    const struct EmailRecipients & recipients);
+    const struct EmailRecipients & recipients,
+    const bool debug);
   EmailSender(const EmailSender &) = delete;
   virtual ~EmailSender();
 

--- a/email/src/context.cpp
+++ b/email/src/context.cpp
@@ -102,7 +102,8 @@ Context::get_receiver() const
   }
   // TODO(christophebedard) have classes use the UserInfo shared_ptr
   static std::shared_ptr<EmailReceiver> receiver = std::make_shared<EmailReceiver>(
-    *options_->get_user_info().get());
+    *options_->get_user_info().get(),
+    options_->debug());
   if (!receiver->is_valid()) {
     receiver->init();
   }
@@ -118,7 +119,8 @@ Context::get_sender() const
   // TODO(christophebedard) have classes use the shared_ptrs
   static std::shared_ptr<EmailSender> sender = std::make_shared<EmailSender>(
     *options_->get_user_info().get(),
-    *options_->get_recipients().get());
+    *options_->get_recipients().get(),
+    options_->debug());
   if (!sender->is_valid()) {
     sender->init();
   }

--- a/email/src/curl/executor.cpp
+++ b/email/src/curl/executor.cpp
@@ -28,12 +28,6 @@ CurlExecutor::CurlExecutor(
   is_valid_(false)
 {}
 
-CurlExecutor::CurlExecutor(
-  const struct ConnectionInfo & connection_info,
-  const struct ProtocolInfo & protocol_info)
-: CurlExecutor(connection_info, protocol_info, get_global_context()->get_options()->debug())
-{}
-
 CurlExecutor::~CurlExecutor()
 {
   context_.fini();

--- a/email/src/email/receiver.cpp
+++ b/email/src/email/receiver.cpp
@@ -30,10 +30,11 @@
 namespace email
 {
 
-EmailReceiver::EmailReceiver(const struct UserInfo & user_info)
+EmailReceiver::EmailReceiver(const struct UserInfo & user_info, const bool debug)
 : CurlExecutor(
     {user_info.host_imap, user_info.username, user_info.password},
-    {"imaps", 993}),
+    {"imaps", 993},
+    debug),
   read_buffer_()
 {}
 

--- a/email/src/email/sender.cpp
+++ b/email/src/email/sender.cpp
@@ -31,10 +31,12 @@ namespace email
 
 EmailSender::EmailSender(
   const struct UserInfo & user_info,
-  const struct EmailRecipients & recipients)
+  const struct EmailRecipients & recipients,
+  const bool debug)
 : CurlExecutor(
     {user_info.host_smtp, user_info.username, user_info.password},
-    {"smtps", 465}),
+    {"smtps", 465},
+    debug),
   recipients_(recipients),
   recipients_list_(nullptr),
   upload_ctx_()

--- a/email/src/example/receive.cpp
+++ b/email/src/example/receive.cpp
@@ -26,7 +26,7 @@ int main(int argc, char ** argv)
 {
   email::init(argc, argv);
   std::shared_ptr<email::Options> options = email::get_global_context()->get_options();
-  email::EmailReceiver receiver(*options->get_user_info().get());
+  email::EmailReceiver receiver(*options->get_user_info().get(), options->debug());
   if (!receiver.init()) {
     return 1;
   }

--- a/email/src/example/send.cpp
+++ b/email/src/example/send.cpp
@@ -27,7 +27,8 @@ int main(int argc, char ** argv)
   std::shared_ptr<email::Options> options = email::get_global_context()->get_options();
   email::EmailSender sender(
     *options->get_user_info().get(),
-    *options->get_recipients().get());
+    *options->get_recipients().get(),
+    options->debug());
   if (!sender.init()) {
     return 1;
   }


### PR DESCRIPTION
Instead of having CurlExecutor fetch it from the context.

This also removes the need for a second CurlExecutor constructor.