### PR TITLE
Use shared_ptrs for sharing and passing data structs around

### DIFF
--- a/email/include/email/email/payload_utils.hpp
+++ b/email/include/email/email/payload_utils.hpp
@@ -15,6 +15,7 @@
 #ifndef EMAIL__EMAIL__PAYLOAD_UTILS_HPP_
 #define EMAIL__EMAIL__PAYLOAD_UTILS_HPP_
 
+#include <memory>
 #include <regex>
 #include <string>
 #include <vector>
@@ -46,7 +47,9 @@ public:
    */
   static
   const std::string
-  build_payload(const struct EmailRecipients & recipients, const struct EmailContent & content);
+  build_payload(
+    std::shared_ptr<const struct EmailRecipients> recipients,
+    const struct EmailContent & content);
 
   /// Create a string list of emails.
   /**

--- a/email/include/email/email/receiver.hpp
+++ b/email/include/email/email/receiver.hpp
@@ -18,6 +18,7 @@
 #include <curl/curl.h>
 
 #include <iostream>
+#include <memory>
 #include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
 #include <regex>
 #include <string>
@@ -40,7 +41,9 @@ public:
    * \param user_info the user information for receiving emails
    * \param debug the debug status
    */
-  explicit EmailReceiver(const struct UserInfo & user_info, const bool debug);
+  explicit EmailReceiver(
+    std::shared_ptr<const struct UserInfo> user_info,
+    const bool debug);
   EmailReceiver(const EmailReceiver &) = delete;
   virtual ~EmailReceiver();
 

--- a/email/include/email/email/sender.hpp
+++ b/email/include/email/email/sender.hpp
@@ -15,6 +15,7 @@
 #ifndef EMAIL__EMAIL__SENDER_HPP_
 #define EMAIL__EMAIL__SENDER_HPP_
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -41,8 +42,8 @@ public:
    * \param debug the debug status
    */
   explicit EmailSender(
-    const struct UserInfo & user_info,
-    const struct EmailRecipients & recipients,
+    std::shared_ptr<const struct UserInfo> user_info,
+    std::shared_ptr<const struct EmailRecipients> recipients,
     const bool debug);
   EmailSender(const EmailSender &) = delete;
   virtual ~EmailSender();
@@ -73,7 +74,7 @@ private:
     int lines_read;
   };
 
-  const struct EmailRecipients recipients_;
+  std::shared_ptr<const struct EmailRecipients> recipients_;
   struct curl_slist * recipients_list_;
   struct UploadData upload_ctx_;
 };

--- a/email/include/email/options.hpp
+++ b/email/include/email/options.hpp
@@ -41,8 +41,8 @@ public:
    * \param debug the debug status
    */
   Options(
-    std::shared_ptr<struct UserInfo> user_info,
-    std::shared_ptr<struct EmailRecipients> recipients,
+    std::shared_ptr<const struct UserInfo> user_info,
+    std::shared_ptr<const struct EmailRecipients> recipients,
     bool debug);
   ~Options();
 
@@ -50,14 +50,14 @@ public:
   /**
    * \return the `UserInfo` object
    */
-  std::shared_ptr<struct UserInfo>
+  std::shared_ptr<const struct UserInfo>
   get_user_info() const;
 
   /// Get email recipient data.
   /**
    * \return the `EmailRecipients` object
    */
-  std::shared_ptr<struct EmailRecipients>
+  std::shared_ptr<const struct EmailRecipients>
   get_recipients() const;
 
   /// Get the debug status.
@@ -86,8 +86,8 @@ public:
   parse_options_from_file();
 
 private:
-  std::shared_ptr<struct UserInfo> user_info_;
-  std::shared_ptr<struct EmailRecipients> recipients_;
+  std::shared_ptr<const struct UserInfo> user_info_;
+  std::shared_ptr<const struct EmailRecipients> recipients_;
   bool debug_;
 
   static const std::regex REGEX_CONFIG_FILE;

--- a/email/include/email/types.hpp
+++ b/email/include/email/types.hpp
@@ -52,14 +52,36 @@ struct UserInfo
   std::string username;
   /// Password.
   std::string password;
+  /// Constructor.
+  UserInfo(
+    const std::string & host_smtp_,
+    const std::string & host_imap_,
+    const std::string & username_,
+    const std::string & password_)
+  : host_smtp(host_smtp_), host_imap(host_imap_), username(username_), password(password_)
+  {}
 };
 
 /// Recipients of an email.
 struct EmailRecipients
 {
-  std::vector<std::string> to;
-  std::vector<std::string> cc;
-  std::vector<std::string> bcc;
+  /// The "to" emails.
+  const std::vector<std::string> to;
+  /// The "cc" emails.
+  const std::vector<std::string> cc;
+  /// The "bcc" emails.
+  const std::vector<std::string> bcc;
+  /// Default constructor.
+  EmailRecipients(
+    const std::vector<std::string> & to_,
+    const std::vector<std::string> & cc_,
+    const std::vector<std::string> & bcc_)
+  : to(to_), cc(cc_), bcc(bcc_)
+  {}
+  /// Constructor with only a single "to" email.
+  explicit EmailRecipients(const std::string & to_)
+  : to({to_}), cc(), bcc()
+  {}
 };
 
 /// Content of an email.

--- a/email/src/context.cpp
+++ b/email/src/context.cpp
@@ -102,7 +102,7 @@ Context::get_receiver() const
   }
   // TODO(christophebedard) have classes use the UserInfo shared_ptr
   static std::shared_ptr<EmailReceiver> receiver = std::make_shared<EmailReceiver>(
-    *options_->get_user_info().get(),
+    options_->get_user_info(),
     options_->debug());
   if (!receiver->is_valid()) {
     receiver->init();
@@ -118,8 +118,8 @@ Context::get_sender() const
   }
   // TODO(christophebedard) have classes use the shared_ptrs
   static std::shared_ptr<EmailSender> sender = std::make_shared<EmailSender>(
-    *options_->get_user_info().get(),
-    *options_->get_recipients().get(),
+    options_->get_user_info(),
+    options_->get_recipients(),
     options_->debug());
   if (!sender->is_valid()) {
     sender->init();

--- a/email/src/email/payload_utils.cpp
+++ b/email/src/email/payload_utils.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
 #include <numeric>
 #include <regex>
 #include <string>
@@ -28,7 +29,7 @@ namespace utils
 
 const std::string
 PayloadUtils::build_payload(
-  const struct EmailRecipients & recipients,
+  std::shared_ptr<const struct EmailRecipients> recipients,
   const struct EmailContent & content)
 {
   // Subjects containing newlines will have the second+ line(s) be moved to the body,
@@ -36,9 +37,9 @@ PayloadUtils::build_payload(
   // seems to handle it correctly even if it contains "\n" instead of "\r\n"
   return utils::string_format(
     "To: %s\r\nCc: %s\r\nBcc: %s\r\nSubject: %s\r\n\r\n%s\r\n",
-    join_list(recipients.to).c_str(),
-    join_list(recipients.cc).c_str(),
-    join_list(recipients.bcc).c_str(),
+    join_list(recipients->to).c_str(),
+    join_list(recipients->cc).c_str(),
+    join_list(recipients->bcc).c_str(),
     cut_string_if_newline(content.subject).c_str(),
     content.body.c_str());
 }

--- a/email/src/email/receiver.cpp
+++ b/email/src/email/receiver.cpp
@@ -18,6 +18,7 @@
 #include <cstring>
 #include <cstdlib>
 #include <iostream>
+#include <memory>
 #include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
 #include <regex>
 #include <string>
@@ -30,9 +31,11 @@
 namespace email
 {
 
-EmailReceiver::EmailReceiver(const struct UserInfo & user_info, const bool debug)
+EmailReceiver::EmailReceiver(
+  std::shared_ptr<const struct UserInfo> user_info,
+  const bool debug)
 : CurlExecutor(
-    {user_info.host_imap, user_info.username, user_info.password},
+    {user_info->host_imap, user_info->username, user_info->password},
     {"imaps", 993},
     debug),
   read_buffer_()

--- a/email/src/email/sender.cpp
+++ b/email/src/email/sender.cpp
@@ -30,11 +30,11 @@ namespace email
 {
 
 EmailSender::EmailSender(
-  const struct UserInfo & user_info,
-  const struct EmailRecipients & recipients,
+  std::shared_ptr<const struct UserInfo> user_info,
+  std::shared_ptr<const struct EmailRecipients> recipients,
   const bool debug)
 : CurlExecutor(
-    {user_info.host_smtp, user_info.username, user_info.password},
+    {user_info->host_smtp, user_info->username, user_info->password},
     {"smtps", 465},
     debug),
   recipients_(recipients),
@@ -79,17 +79,17 @@ EmailSender::init_options()
   curl_easy_setopt(
     context_.get_handle(), CURLOPT_MAIL_FROM, context_.get_connection_info().username.c_str());
   // Add all destination emails to the list of recipients
-  if (0 == recipients_.to.size() + recipients_.cc.size() + recipients_.bcc.size()) {
+  if (0 == recipients_->to.size() + recipients_->cc.size() + recipients_->bcc.size()) {
     std::cerr << "no recipients for EmailSender" << std::endl;
     return false;
   }
-  for (auto & email_to : recipients_.to) {
+  for (auto & email_to : recipients_->to) {
     recipients_list_ = curl_slist_append(recipients_list_, email_to.c_str());
   }
-  for (auto & email_cc : recipients_.cc) {
+  for (auto & email_cc : recipients_->cc) {
     recipients_list_ = curl_slist_append(recipients_list_, email_cc.c_str());
   }
-  for (auto & email_bcc : recipients_.bcc) {
+  for (auto & email_bcc : recipients_->bcc) {
     recipients_list_ = curl_slist_append(recipients_list_, email_bcc.c_str());
   }
   curl_easy_setopt(context_.get_handle(), CURLOPT_MAIL_RCPT, recipients_list_);

--- a/email/src/example/receive.cpp
+++ b/email/src/example/receive.cpp
@@ -26,7 +26,7 @@ int main(int argc, char ** argv)
 {
   email::init(argc, argv);
   std::shared_ptr<email::Options> options = email::get_global_context()->get_options();
-  email::EmailReceiver receiver(*options->get_user_info().get(), options->debug());
+  email::EmailReceiver receiver(options->get_user_info(), options->debug());
   if (!receiver.init()) {
     return 1;
   }

--- a/email/src/example/send.cpp
+++ b/email/src/example/send.cpp
@@ -26,8 +26,8 @@ int main(int argc, char ** argv)
   email::init(argc, argv);
   std::shared_ptr<email::Options> options = email::get_global_context()->get_options();
   email::EmailSender sender(
-    *options->get_user_info().get(),
-    *options->get_recipients().get(),
+    options->get_user_info(),
+    options->get_recipients(),
     options->debug());
   if (!sender.init()) {
     return 1;

--- a/email/src/options.cpp
+++ b/email/src/options.cpp
@@ -27,8 +27,8 @@ namespace email
 {
 
 Options::Options(
-  std::shared_ptr<struct UserInfo> user_info,
-  std::shared_ptr<struct EmailRecipients> recipients,
+  std::shared_ptr<const struct UserInfo> user_info,
+  std::shared_ptr<const struct EmailRecipients> recipients,
   bool debug)
 : user_info_(user_info),
   recipients_(recipients),
@@ -37,13 +37,13 @@ Options::Options(
 
 Options::~Options() {}
 
-std::shared_ptr<struct UserInfo>
+std::shared_ptr<const struct UserInfo>
 Options::get_user_info() const
 {
   return user_info_;
 }
 
-std::shared_ptr<struct EmailRecipients>
+std::shared_ptr<const struct EmailRecipients>
 Options::get_recipients() const
 {
   return recipients_;
@@ -63,13 +63,13 @@ Options::parse_options_from_args(int argc, char const * const argv[])
     std::cerr << Options::USAGE_CLI_ARGS << std::endl;
     return std::nullopt;
   }
-  std::shared_ptr<struct UserInfo> user_info = std::make_shared<struct UserInfo>();
-  user_info->host_smtp = std::string(argv[1]);
-  user_info->host_imap = std::string(argv[2]);
-  user_info->username = std::string(argv[3]);
-  user_info->password = std::string(argv[4]);
-  std::shared_ptr<struct EmailRecipients> recipients = std::make_shared<struct EmailRecipients>();
-  recipients->to = {std::string(argv[5])};
+  std::shared_ptr<const struct UserInfo> user_info = std::make_shared<const struct UserInfo>(
+    std::string(argv[1]),
+    std::string(argv[2]),
+    std::string(argv[3]),
+    std::string(argv[4]));
+  std::shared_ptr<const struct EmailRecipients> recipients =
+    std::make_shared<const struct EmailRecipients>(std::string(argv[5]));
   bool debug = false;
   if (7 == argc) {
     const std::string argv6 = std::string(argv[6]);
@@ -109,15 +109,16 @@ Options::parse_options_from_file()
     std::cerr << "invalid config file" << std::endl;
     return std::nullopt;
   }
-  std::shared_ptr<struct UserInfo> user_info = std::make_shared<struct UserInfo>();
-  user_info->host_smtp = matches[1].str();
-  user_info->host_imap = matches[2].str();
-  user_info->username = matches[3].str();
-  user_info->password = matches[4].str();
-  std::shared_ptr<struct EmailRecipients> recipients = std::make_shared<struct EmailRecipients>();
-  recipients->to = utils::split_email_list(matches[5].str());
-  recipients->cc = utils::split_email_list(matches[6].str());
-  recipients->bcc = utils::split_email_list(matches[7].str());
+  std::shared_ptr<const struct UserInfo> user_info = std::make_shared<const struct UserInfo>(
+    matches[1].str(),
+    matches[2].str(),
+    matches[3].str(),
+    matches[4].str());
+  std::shared_ptr<const struct EmailRecipients> recipients =
+    std::make_shared<const struct EmailRecipients>(
+    utils::split_email_list(matches[5].str()),
+    utils::split_email_list(matches[6].str()),
+    utils::split_email_list(matches[7].str()));
   const std::string debug_env_var = utils::get_env_var(Options::ENV_VAR_DEBUG);
   return std::make_shared<Options>(
     user_info,

--- a/email/test/test_utils.cpp
+++ b/email/test/test_utils.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <optional> // NOLINT cpplint mistakes <optional> for a C system header
 #include <string>
 #include <vector>
@@ -48,7 +49,8 @@ TEST(TestUtils, build_payload) {
     "Bcc: \r\n" \
     "Subject: this is my awesome subject\r\n\r\n" \
     "this is the email's body\r\n";
-  const struct email::EmailRecipients recipients_one = {{"my@email.com"}, {}, {}};
+  std::shared_ptr<const struct email::EmailRecipients> recipients_one =
+    std::make_shared<const struct email::EmailRecipients>("my@email.com");
   const struct email::EmailContent content_one_line = {
     {"this is my awesome subject"}, {"this is the email's body"}};
   EXPECT_EQ(
@@ -61,10 +63,11 @@ TEST(TestUtils, build_payload) {
     "Bcc: first@email.ca, second@email.net, third@email.de\r\n" \
     "Subject: this is my awesome subject\r\n\r\n" \
     "this is the email's body\r\n";
-  const struct email::EmailRecipients recipients_multiple = {
-    {"my@email.com", "another@email.com"},
-    {"onecc@email.ca"},
-    {"first@email.ca", "second@email.net", "third@email.de"}};
+  std::shared_ptr<const struct email::EmailRecipients> recipients_multiple =
+    std::make_shared<const struct email::EmailRecipients>(
+    std::vector<std::string>{"my@email.com", "another@email.com"},
+    std::vector<std::string>{"onecc@email.ca"},
+    std::vector<std::string>{"first@email.ca", "second@email.net", "third@email.de"});
   EXPECT_EQ(
     payload_multiple_recipients,
     email::utils::PayloadUtils::build_payload(recipients_multiple, content_one_line));


### PR DESCRIPTION
Instead of copying the `struct`s a few times.

Another PR should add aliases to simplify the code a bit.

Closes #36