### PR TITLE
Use shared_ptr aliases for UserInfo & EmailRecipients

### DIFF
--- a/email/include/email/email/payload_utils.hpp
+++ b/email/include/email/email/payload_utils.hpp
@@ -48,7 +48,7 @@ public:
   static
   const std::string
   build_payload(
-    std::shared_ptr<const struct EmailRecipients> recipients,
+    EmailRecipients::SharedPtrConst recipients,
     const struct EmailContent & content);
 
   /// Create a string list of emails.

--- a/email/include/email/email/receiver.hpp
+++ b/email/include/email/email/receiver.hpp
@@ -42,7 +42,7 @@ public:
    * \param debug the debug status
    */
   explicit EmailReceiver(
-    std::shared_ptr<const struct UserInfo> user_info,
+    UserInfo::SharedPtrConst user_info,
     const bool debug);
   EmailReceiver(const EmailReceiver &) = delete;
   virtual ~EmailReceiver();

--- a/email/include/email/email/sender.hpp
+++ b/email/include/email/email/sender.hpp
@@ -42,8 +42,8 @@ public:
    * \param debug the debug status
    */
   explicit EmailSender(
-    std::shared_ptr<const struct UserInfo> user_info,
-    std::shared_ptr<const struct EmailRecipients> recipients,
+    UserInfo::SharedPtrConst user_info,
+    EmailRecipients::SharedPtrConst recipients,
     const bool debug);
   EmailSender(const EmailSender &) = delete;
   virtual ~EmailSender();
@@ -74,7 +74,7 @@ private:
     int lines_read;
   };
 
-  std::shared_ptr<const struct EmailRecipients> recipients_;
+  EmailRecipients::SharedPtrConst recipients_;
   struct curl_slist * recipients_list_;
   struct UploadData upload_ctx_;
 };

--- a/email/include/email/options.hpp
+++ b/email/include/email/options.hpp
@@ -41,8 +41,8 @@ public:
    * \param debug the debug status
    */
   Options(
-    std::shared_ptr<const struct UserInfo> user_info,
-    std::shared_ptr<const struct EmailRecipients> recipients,
+    UserInfo::SharedPtrConst user_info,
+    EmailRecipients::SharedPtrConst recipients,
     bool debug);
   ~Options();
 
@@ -50,14 +50,14 @@ public:
   /**
    * \return the `UserInfo` object
    */
-  std::shared_ptr<const struct UserInfo>
+  UserInfo::SharedPtrConst
   get_user_info() const;
 
   /// Get email recipient data.
   /**
    * \return the `EmailRecipients` object
    */
-  std::shared_ptr<const struct EmailRecipients>
+  EmailRecipients::SharedPtrConst
   get_recipients() const;
 
   /// Get the debug status.
@@ -86,8 +86,8 @@ public:
   parse_options_from_file();
 
 private:
-  std::shared_ptr<const struct UserInfo> user_info_;
-  std::shared_ptr<const struct EmailRecipients> recipients_;
+  UserInfo::SharedPtrConst user_info_;
+  EmailRecipients::SharedPtrConst recipients_;
   bool debug_;
 
   static const std::regex REGEX_CONFIG_FILE;

--- a/email/include/email/types.hpp
+++ b/email/include/email/types.hpp
@@ -15,6 +15,10 @@
 #ifndef EMAIL__TYPES_HPP_
 #define EMAIL__TYPES_HPP_
 
+#define SHARED_PTR_CONST(name) \
+  using SharedPtrConst = std::shared_ptr<const struct name>;
+
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -60,6 +64,7 @@ struct UserInfo
     const std::string & password_)
   : host_smtp(host_smtp_), host_imap(host_imap_), username(username_), password(password_)
   {}
+  SHARED_PTR_CONST(UserInfo)
 };
 
 /// Recipients of an email.
@@ -82,6 +87,7 @@ struct EmailRecipients
   explicit EmailRecipients(const std::string & to_)
   : to({to_}), cc(), bcc()
   {}
+  SHARED_PTR_CONST(EmailRecipients)
 };
 
 /// Content of an email.

--- a/email/src/email/payload_utils.cpp
+++ b/email/src/email/payload_utils.cpp
@@ -29,7 +29,7 @@ namespace utils
 
 const std::string
 PayloadUtils::build_payload(
-  std::shared_ptr<const struct EmailRecipients> recipients,
+  EmailRecipients::SharedPtrConst recipients,
   const struct EmailContent & content)
 {
   // Subjects containing newlines will have the second+ line(s) be moved to the body,

--- a/email/src/email/receiver.cpp
+++ b/email/src/email/receiver.cpp
@@ -32,7 +32,7 @@ namespace email
 {
 
 EmailReceiver::EmailReceiver(
-  std::shared_ptr<const struct UserInfo> user_info,
+  UserInfo::SharedPtrConst user_info,
   const bool debug)
 : CurlExecutor(
     {user_info->host_imap, user_info->username, user_info->password},

--- a/email/src/email/sender.cpp
+++ b/email/src/email/sender.cpp
@@ -30,8 +30,8 @@ namespace email
 {
 
 EmailSender::EmailSender(
-  std::shared_ptr<const struct UserInfo> user_info,
-  std::shared_ptr<const struct EmailRecipients> recipients,
+  UserInfo::SharedPtrConst user_info,
+  EmailRecipients::SharedPtrConst recipients,
   const bool debug)
 : CurlExecutor(
     {user_info->host_smtp, user_info->username, user_info->password},

--- a/email/src/options.cpp
+++ b/email/src/options.cpp
@@ -27,8 +27,8 @@ namespace email
 {
 
 Options::Options(
-  std::shared_ptr<const struct UserInfo> user_info,
-  std::shared_ptr<const struct EmailRecipients> recipients,
+  UserInfo::SharedPtrConst user_info,
+  EmailRecipients::SharedPtrConst recipients,
   bool debug)
 : user_info_(user_info),
   recipients_(recipients),
@@ -37,13 +37,13 @@ Options::Options(
 
 Options::~Options() {}
 
-std::shared_ptr<const struct UserInfo>
+UserInfo::SharedPtrConst
 Options::get_user_info() const
 {
   return user_info_;
 }
 
-std::shared_ptr<const struct EmailRecipients>
+EmailRecipients::SharedPtrConst
 Options::get_recipients() const
 {
   return recipients_;
@@ -63,12 +63,12 @@ Options::parse_options_from_args(int argc, char const * const argv[])
     std::cerr << Options::USAGE_CLI_ARGS << std::endl;
     return std::nullopt;
   }
-  std::shared_ptr<const struct UserInfo> user_info = std::make_shared<const struct UserInfo>(
+  UserInfo::SharedPtrConst user_info = std::make_shared<const struct UserInfo>(
     std::string(argv[1]),
     std::string(argv[2]),
     std::string(argv[3]),
     std::string(argv[4]));
-  std::shared_ptr<const struct EmailRecipients> recipients =
+  EmailRecipients::SharedPtrConst recipients =
     std::make_shared<const struct EmailRecipients>(std::string(argv[5]));
   bool debug = false;
   if (7 == argc) {
@@ -109,12 +109,12 @@ Options::parse_options_from_file()
     std::cerr << "invalid config file" << std::endl;
     return std::nullopt;
   }
-  std::shared_ptr<const struct UserInfo> user_info = std::make_shared<const struct UserInfo>(
+  UserInfo::SharedPtrConst user_info = std::make_shared<const struct UserInfo>(
     matches[1].str(),
     matches[2].str(),
     matches[3].str(),
     matches[4].str());
-  std::shared_ptr<const struct EmailRecipients> recipients =
+  EmailRecipients::SharedPtrConst recipients =
     std::make_shared<const struct EmailRecipients>(
     utils::split_email_list(matches[5].str()),
     utils::split_email_list(matches[6].str()),

--- a/email/test/test_utils.cpp
+++ b/email/test/test_utils.cpp
@@ -49,7 +49,7 @@ TEST(TestUtils, build_payload) {
     "Bcc: \r\n" \
     "Subject: this is my awesome subject\r\n\r\n" \
     "this is the email's body\r\n";
-  std::shared_ptr<const struct email::EmailRecipients> recipients_one =
+  email::EmailRecipients::SharedPtrConst recipients_one =
     std::make_shared<const struct email::EmailRecipients>("my@email.com");
   const struct email::EmailContent content_one_line = {
     {"this is my awesome subject"}, {"this is the email's body"}};
@@ -63,7 +63,7 @@ TEST(TestUtils, build_payload) {
     "Bcc: first@email.ca, second@email.net, third@email.de\r\n" \
     "Subject: this is my awesome subject\r\n\r\n" \
     "this is the email's body\r\n";
-  std::shared_ptr<const struct email::EmailRecipients> recipients_multiple =
+  email::EmailRecipients::SharedPtrConst recipients_multiple =
     std::make_shared<const struct email::EmailRecipients>(
     std::vector<std::string>{"my@email.com", "another@email.com"},
     std::vector<std::string>{"onecc@email.ca"},


### PR DESCRIPTION
This simplifies code a bit.

Follow-up to #37