### PR TITLE
Fix options parsing from CLI args

### DIFF
--- a/email/src/context.cpp
+++ b/email/src/context.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdlib>
 #include <memory>
 #include <string>
 
@@ -63,7 +64,8 @@ Context::init(int argc, char const * const argv[])
   }
   auto options = Options::parse_options_from_args(argc, argv);
   if (!options) {
-    throw ContextInitFailedError();
+    // Exit with non-zero instead of throwing an exception, since this is CLI args-related
+    exit(1);
   }
   options_ = options.value();
   is_valid_ = true;

--- a/email/src/options.cpp
+++ b/email/src/options.cpp
@@ -59,7 +59,7 @@ std::optional<std::shared_ptr<Options>>
 Options::parse_options_from_args(int argc, char const * const argv[])
 {
   // TODO(christophebedard) remove completely or refactor/extract parsing logic
-  if (6 == argc || 7 == argc) {
+  if (!(6 == argc || 7 == argc)) {
     std::cerr << Options::USAGE_CLI_ARGS << std::endl;
     return std::nullopt;
   }


### PR DESCRIPTION
The first condition was wrong.

Also, this makes the context do exit(1) on failure when initialising with args.