### PR TITLE
Add EmailSender::reply() to reply to an email

### DIFF
--- a/email/include/email/email/payload_utils.hpp
+++ b/email/include/email/email/payload_utils.hpp
@@ -16,6 +16,7 @@
 #define EMAIL__EMAIL__PAYLOAD_UTILS_HPP_
 
 #include <memory>
+#include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
 #include <regex>
 #include <string>
 #include <vector>
@@ -43,13 +44,15 @@ public:
   /**
    * \param recipients the recipients
    * \param content the content of the email
+   * \param reply_ref the reply reference (Message-ID of the email to reply to)
    * \return the payload
    */
   static
   const std::string
   build_payload(
     EmailRecipients::SharedPtrConst recipients,
-    const struct EmailContent & content);
+    const struct EmailContent & content,
+    std::optional<std::string> reply_ref = std::nullopt);
 
   /// Create a string list of emails.
   /**

--- a/email/include/email/email/sender.hpp
+++ b/email/include/email/email/sender.hpp
@@ -56,12 +56,29 @@ public:
   bool
   send(const struct EmailContent & content);
 
+  /// Reply to an email.
+  /**
+   * \param content the content
+   * \param email the email to reply to
+   * \return true if successful, false otherwise
+   */
+  bool
+  reply(const struct EmailContent & content, const struct EmailData & email);
+
 protected:
   virtual
   bool
   init_options();
 
 private:
+  /// Send payload.
+  /**
+   * \param payload the payload
+   * \return true if successful, false otherwise
+   */
+  bool
+  send_payload(const std::string & payload);
+
   /// Read callback for curl upload.
   static
   size_t

--- a/email/src/email/payload_utils.cpp
+++ b/email/src/email/payload_utils.cpp
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <numeric>
+#include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
 #include <regex>
 #include <string>
 #include <vector>
@@ -30,13 +31,17 @@ namespace utils
 const std::string
 PayloadUtils::build_payload(
   EmailRecipients::SharedPtrConst recipients,
-  const struct EmailContent & content)
+  const struct EmailContent & content,
+  std::optional<std::string> reply_ref)
 {
   // Subjects containing newlines will have the second+ line(s) be moved to the body,
   // but for the sake of simplicity, we will cut it out. As for the body, curl
   // seems to handle it correctly even if it contains "\n" instead of "\r\n"
   return utils::string_format(
+    "In-Reply-To: %s\r\nReferences: %s\r\n"
     "To: %s\r\nCc: %s\r\nBcc: %s\r\nSubject: %s\r\n\r\n%s\r\n",
+    (reply_ref.has_value() ? reply_ref.value().c_str() : ""),
+    (reply_ref.has_value() ? reply_ref.value().c_str() : ""),
     join_list(recipients->to).c_str(),
     join_list(recipients->cc).c_str(),
     join_list(recipients->bcc).c_str(),

--- a/email/src/email/sender.cpp
+++ b/email/src/email/sender.cpp
@@ -104,20 +104,28 @@ EmailSender::init_options()
 bool
 EmailSender::send(const struct EmailContent & content)
 {
+  return send_payload(utils::PayloadUtils::build_payload(recipients_, content));
+}
+
+bool
+EmailSender::reply(const struct EmailContent & content, const struct EmailData & email)
+{
+  return send_payload(utils::PayloadUtils::build_payload(recipients_, content, email.message_id));
+}
+
+bool
+EmailSender::send_payload(const std::string & payload)
+{
   if (!is_valid()) {
     std::cerr << "not initialized!" << std::endl;
     return false;
   }
-
-  const std::string payload = utils::PayloadUtils::build_payload(recipients_, content);
   if (debug_) {
-    std::cout << "payload:" << std::endl << payload << std::endl;
+    std::cout << "[PAYLOAD]:" << std::endl << payload << std::endl;
   }
-
   // Reset upload data
   upload_ctx_.payload = payload.c_str();
   upload_ctx_.lines_read = 0;
-
   if (!context_.execute()) {
     return false;
   }

--- a/email/test/test_utils.cpp
+++ b/email/test/test_utils.cpp
@@ -71,6 +71,7 @@ TEST(TestUtils, split_email_list) {
 TEST(TestUtils, build_payload) {
   // Check handling of multiple recipients
   std::string payload_one_recipient = \
+    "In-Reply-To: \r\nReferences: \r\n" \
     "To: my@email.com\r\n" \
     "Cc: \r\n" \
     "Bcc: \r\n" \
@@ -85,6 +86,7 @@ TEST(TestUtils, build_payload) {
     email::utils::PayloadUtils::build_payload(recipients_one, content_one_line));
 
   std::string payload_multiple_recipients = \
+    "In-Reply-To: \r\nReferences: \r\n" \
     "To: my@email.com, another@email.com\r\n" \
     "Cc: onecc@email.ca\r\n" \
     "Bcc: first@email.ca, second@email.net, third@email.de\r\n" \
@@ -104,6 +106,7 @@ TEST(TestUtils, build_payload) {
     {"this is my awesome subject that stops here\nor not!"},
     {"this is the email's body\non multiple lines!"}};
   std::string payload_multiple_recipients_newlines = \
+    "In-Reply-To: \r\nReferences: \r\n" \
     "To: my@email.com, another@email.com\r\n" \
     "Cc: onecc@email.ca\r\n" \
     "Bcc: first@email.ca, second@email.net, third@email.de\r\n" \


### PR DESCRIPTION
This allows replying to an email. It works by including the Message-ID header value of the email being replied to in the In-Reply-To and References headers of the reply email.

See: https://stackoverflow.com/a/29531009/6476709