### PR TITLE
Send reply to sender of original email

### DIFF
--- a/email/include/email/email/payload_utils.hpp
+++ b/email/include/email/email/payload_utils.hpp
@@ -42,6 +42,24 @@ public:
 
   /// Build curl email payload from recipients and content.
   /**
+   * \param to the "TO" recipients
+   * \param cc the "CC" recipients
+   * \param bcc the "BCC" recipients
+   * \param content the content of the email
+   * \param reply_ref the reply reference (Message-ID of the email to reply to)
+   * \return the payload
+   */
+  static
+  const std::string
+  build_payload(
+    const std::vector<std::string> & to,
+    const std::vector<std::string> & cc,
+    const std::vector<std::string> & bcc,
+    const struct EmailContent & content,
+    std::optional<std::string> reply_ref = std::nullopt);
+
+  /// Build curl email payload from recipients and content.
+  /**
    * \param recipients the recipients
    * \param content the content of the email
    * \param reply_ref the reply reference (Message-ID of the email to reply to)

--- a/email/src/email/payload_utils.cpp
+++ b/email/src/email/payload_utils.cpp
@@ -30,7 +30,9 @@ namespace utils
 
 const std::string
 PayloadUtils::build_payload(
-  EmailRecipients::SharedPtrConst recipients,
+  const std::vector<std::string> & to,
+  const std::vector<std::string> & cc,
+  const std::vector<std::string> & bcc,
   const struct EmailContent & content,
   std::optional<std::string> reply_ref)
 {
@@ -42,11 +44,21 @@ PayloadUtils::build_payload(
     "To: %s\r\nCc: %s\r\nBcc: %s\r\nSubject: %s\r\n\r\n%s\r\n",
     (reply_ref.has_value() ? reply_ref.value().c_str() : ""),
     (reply_ref.has_value() ? reply_ref.value().c_str() : ""),
-    join_list(recipients->to).c_str(),
-    join_list(recipients->cc).c_str(),
-    join_list(recipients->bcc).c_str(),
+    join_list(to).c_str(),
+    join_list(cc).c_str(),
+    join_list(bcc).c_str(),
     cut_string_if_newline(content.subject).c_str(),
     content.body.c_str());
+}
+
+const std::string
+PayloadUtils::build_payload(
+  EmailRecipients::SharedPtrConst recipients,
+  const struct EmailContent & content,
+  std::optional<std::string> reply_ref)
+{
+  return PayloadUtils::build_payload(
+    recipients->to, recipients->cc, recipients->bcc, content, reply_ref);
 }
 
 const std::string

--- a/email/src/email/sender.cpp
+++ b/email/src/email/sender.cpp
@@ -110,7 +110,8 @@ EmailSender::send(const struct EmailContent & content)
 bool
 EmailSender::reply(const struct EmailContent & content, const struct EmailData & email)
 {
-  return send_payload(utils::PayloadUtils::build_payload(recipients_, content, email.message_id));
+  return send_payload(
+    utils::PayloadUtils::build_payload({email.from}, {}, {}, content, email.message_id));
 }
 
 bool


### PR DESCRIPTION
Follow-up to #47

This uses the "From" value of the original email so that the reply is sent to that email instead of using the recipients_ member.