### PR TITLE
Add SubscriberManager to poll for emails and give to subscribers

### DIFF
--- a/email/CMakeLists.txt
+++ b/email/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SOURCES
   src/pub_sub.cpp
   src/publisher.cpp
   src/subscriber.cpp
+  src/subscriber_manager.cpp
   src/utils.cpp
 )
 

--- a/email/include/email/context.hpp
+++ b/email/include/email/context.hpp
@@ -23,6 +23,7 @@
 #include "email/email/receiver.hpp"
 #include "email/email/sender.hpp"
 #include "email/options.hpp"
+#include "email/subscriber_manager.hpp"
 #include "email/types.hpp"
 #include "email/visibility_control.hpp"
 
@@ -133,6 +134,16 @@ public:
    */
   std::shared_ptr<EmailSender>
   get_sender() const;
+
+  /// Get the subscriber manager.
+  /**
+   * Will have been started.
+   *
+   * \return the `SubscriberManager` object
+   * \throw `ContextNotInitializedError` if context has not been initialized
+   */
+  std::shared_ptr<SubscriberManager>
+  get_subscriber_manager() const;
 
 private:
   std::shared_ptr<Options> options_;

--- a/email/include/email/email/receiver.hpp
+++ b/email/include/email/email/receiver.hpp
@@ -17,6 +17,7 @@
 
 #include <curl/curl.h>
 
+#include <atomic>
 #include <iostream>
 #include <memory>
 #include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
@@ -46,6 +47,9 @@ public:
     const bool debug);
   EmailReceiver(const EmailReceiver &) = delete;
   virtual ~EmailReceiver();
+
+  void
+  shutdown();
 
   /// Get a new email.
   /**
@@ -90,6 +94,7 @@ private:
   write_callback(void * contents, size_t size, size_t nmemb, void * userp);
 
   std::string read_buffer_;
+  std::atomic_bool do_shutdown_;
 };
 
 }  // namespace email

--- a/email/include/email/safe_queue.hpp
+++ b/email/include/email/safe_queue.hpp
@@ -1,0 +1,86 @@
+// Copyright 2020 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EMAIL__SAFE_QUEUE_HPP_
+#define EMAIL__SAFE_QUEUE_HPP_
+
+#include <mutex>
+#include <queue>
+#include <utility>
+
+namespace email
+{
+
+/// Simple thread-safe queue.
+/**
+ * Note: probably not ideal.
+ *
+ * \tparam T the queue element type
+ */
+template<class T>
+class SafeQueue
+{
+public:
+  /// Constructor.
+  SafeQueue()
+  : queue_mutex_(),
+    queue_()
+  {}
+  SafeQueue(const SafeQueue &) = delete;
+  ~SafeQueue() {}
+
+  bool
+  empty()
+  {
+    std::lock_guard<std::mutex> lock(queue_mutex_);
+    return queue_.empty();
+  }
+
+  void
+  push(const T && element)
+  {
+    std::lock_guard<std::mutex> lock(queue_mutex_);
+    queue_.push(std::move(element));
+  }
+
+  void
+  pop()
+  {
+    std::lock_guard<std::mutex> lock(queue_mutex_);
+    queue_.pop();
+  }
+
+  const T &
+  front()
+  {
+    std::lock_guard<std::mutex> lock(queue_mutex_);
+    return queue_.front();
+  }
+
+  const T
+  dequeue()
+  {
+    const T message = front();
+    pop();
+    return message;
+  }
+
+private:
+  std::mutex queue_mutex_;
+  std::queue<T> queue_;
+};
+
+}  // namespace email
+
+#endif  // EMAIL__SAFE_QUEUE_HPP_

--- a/email/include/email/subscriber.hpp
+++ b/email/include/email/subscriber.hpp
@@ -16,10 +16,11 @@
 #define EMAIL__SUBSCRIBER_HPP_
 
 #include <memory>
+#include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
 #include <string>
 
-#include "email/email/receiver.hpp"
 #include "email/pub_sub.hpp"
+#include "email/safe_queue.hpp"
 #include "email/types.hpp"
 #include "email/visibility_control.hpp"
 
@@ -29,6 +30,7 @@ namespace email
 /// Message subscriber.
 /**
  * Uses emails, with the topic as the email subject and the data as the email body.
+ * TODO(christophebedard) add take to get a vector of all available messages?
  */
 class Subscriber : public PubSubObject
 {
@@ -41,17 +43,32 @@ public:
   Subscriber(const Subscriber &) = delete;
   virtual ~Subscriber();
 
-  /// Get a new message.
+  /// Check if the subscriber has a message.
   /**
-   * TODO(christophebedard) turn this into polling
-   *
-   * \return the new message
+   * \return true if there is a message, false otherwise
    */
-  std::string
+  bool
+  has_message();
+
+  /// Get a message if there is one.
+  /**
+   * \return the message, or `std::nullopt` if there is none
+   */
+  std::optional<std::string>
   get_message();
 
+  /// Get a message, waiting until one is available.
+  /**
+   * TODO(christophebedard) use a timeout
+   * TODO(christophebedard) sleep a bit
+   *
+   * \return the message
+   */
+  std::string
+  get_message_and_wait();
+
 private:
-  std::shared_ptr<EmailReceiver> receiver_;
+  std::shared_ptr<SafeQueue<std::string>> messages_;
 };
 
 }  // namespace email

--- a/email/include/email/subscriber_manager.hpp
+++ b/email/include/email/subscriber_manager.hpp
@@ -1,0 +1,95 @@
+// Copyright 2020 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EMAIL__SUBSCRIBER_MANAGER_HPP_
+#define EMAIL__SUBSCRIBER_MANAGER_HPP_
+
+#include <atomic>
+#include <chrono>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include "email/email/receiver.hpp"
+#include "email/safe_queue.hpp"
+#include "email/types.hpp"
+#include "email/visibility_control.hpp"
+
+namespace email
+{
+
+/// Manager for distributing messages to susbcribers.
+/**
+ * Does the polling for new emails and distributes them to the right subscriber(s).
+ */
+class SubscriberManager
+{
+public:
+  /// Constructor.
+  /**
+   * \param receiver the email receiver to use for getting emails
+   * \param debug the debug status
+   */
+  explicit SubscriberManager(std::shared_ptr<EmailReceiver> receiver, const bool debug);
+  SubscriberManager(const SubscriberManager &) = delete;
+  ~SubscriberManager();
+
+  /// Register a subscriber with the manager.
+  /**
+   * TODO(christophebedard) support multiple subscribers for a topic (using a multimap)
+   *
+   * \param topic the topic
+   * \param message_queue the message queue of the subscriber
+   */
+  void
+  register_subscriber(
+    const std::string & topic,
+    std::shared_ptr<SafeQueue<std::string>> message_queue);
+
+  /// Get status.
+  /**
+   * \return true if it has been started, false otherwise
+   */
+  bool
+  has_started() const;
+
+  /// Start manager.
+  void
+  start();
+
+  /// Shut down manager and internal thread.
+  void
+  shutdown();
+
+private:
+  /// Thread function for polling for new emails.
+  void
+  poll_thread();
+
+  std::shared_ptr<EmailReceiver> receiver_;
+  bool debug_;
+  bool has_started_;
+  std::atomic_bool do_shutdown_;
+  std::thread thread_;
+  std::mutex map_mutex_;
+  std::map<std::string, std::shared_ptr<SafeQueue<std::string>>> map_;
+
+  static constexpr auto POLLING_PERIOD = std::chrono::milliseconds(1);
+};
+
+}  // namespace email
+
+#endif  // EMAIL__SUBSCRIBER_MANAGER_HPP_

--- a/email/src/context.cpp
+++ b/email/src/context.cpp
@@ -77,7 +77,8 @@ Context::shutdown()
   if (!is_valid()) {
     return false;
   }
-  // TODO(christophebedard) actually do something
+  // TODO(christophebedard) don't call if it hasn't been started?
+  get_subscriber_manager()->shutdown();
   return true;
 }
 
@@ -125,6 +126,21 @@ Context::get_sender() const
     sender->init();
   }
   return sender;
+}
+
+std::shared_ptr<SubscriberManager>
+Context::get_subscriber_manager() const
+{
+  if (!is_valid()) {
+    throw ContextNotInitializedError();
+  }
+  static std::shared_ptr<SubscriberManager> manager = std::make_shared<SubscriberManager>(
+    get_receiver(),
+    options_->debug());
+  if (!manager->has_started()) {
+    manager->start();
+  }
+  return manager;
 }
 
 }  // namespace email

--- a/email/src/example/pub.cpp
+++ b/email/src/example/pub.cpp
@@ -23,5 +23,6 @@ int main()
   email::Publisher pub("/my_topic");
   std::cout << "publishing message" << std::endl;
   pub.publish("my awesome message!");
+  email::shutdown();
   return 0;
 }

--- a/email/src/example/sub.cpp
+++ b/email/src/example/sub.cpp
@@ -22,6 +22,8 @@ int main()
   email::init();
   email::Subscriber sub("/my_topic");
   std::cout << "getting message..." << std::endl;
-  std::cout << "got message: " << sub.get_message() << std::endl;
+  auto message = sub.get_message_and_wait();
+  std::cout << "got message: " << message << std::endl;
+  email::shutdown();
   return 0;
 }

--- a/email/src/subscriber_manager.cpp
+++ b/email/src/subscriber_manager.cpp
@@ -1,0 +1,106 @@
+// Copyright 2020 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include "email/email/receiver.hpp"
+#include "email/safe_queue.hpp"
+#include "email/subscriber_manager.hpp"
+#include "email/types.hpp"
+
+namespace email
+{
+
+SubscriberManager::SubscriberManager(std::shared_ptr<EmailReceiver> receiver, const bool debug)
+: receiver_(receiver),
+  debug_(debug),
+  has_started_(false),
+  do_shutdown_(false),
+  thread_({}),
+  map_mutex_(),
+  map_()
+{}
+
+SubscriberManager::~SubscriberManager() {}
+
+void
+SubscriberManager::register_subscriber(
+  const std::string & topic,
+  std::shared_ptr<SafeQueue<std::string>> message_queue)
+{
+  std::lock_guard<std::mutex> lock(map_mutex_);
+  map_.insert({topic, message_queue});
+}
+
+bool
+SubscriberManager::has_started() const
+{
+  return has_started_;
+}
+
+void
+SubscriberManager::start()
+{
+  has_started_ = true;
+  thread_ = std::thread(&SubscriberManager::poll_thread, this);
+}
+
+void
+SubscriberManager::shutdown()
+{
+  receiver_->shutdown();
+  do_shutdown_ = true;
+  thread_.join();
+}
+
+void
+SubscriberManager::poll_thread()
+{
+  while (!do_shutdown_.load()) {
+    // Get new email
+    std::optional<struct EmailData> email_data = std::nullopt;
+    while (!email_data && !do_shutdown_.load()) {
+      email_data = receiver_->get_email();
+      std::this_thread::sleep_for(POLLING_PERIOD);
+    }
+    // Break now if shutting down
+    if (do_shutdown_.load()) {
+      break;
+    }
+    const std::string & topic = email_data.value().content.subject;
+    // TODO(christophebedard) make this better
+    {
+      // Get queue corresponding to that topic
+      std::lock_guard<std::mutex> lock(map_mutex_);
+      auto it = map_.find(topic);
+      if (it != map_.end()) {
+        // Push message content to the queue
+        // TODO(christophebedard) sync?
+        it->second->push(std::move(email_data.value().content.body));
+      } else if (debug_) {
+        std::cout << "topic not found: " << topic << std::endl;
+      }
+    }
+  }
+}
+
+}  // namespace email


### PR DESCRIPTION
This moves the email polling logic (using EmailReceiver) from the Subscriber to a central location: the SubscriberManager. Each Subscriber has a queue of messages. It registers its topic name and its
queue with the manager, which keeps a map. The manager starts a thread that polls for new emails. When it gets one, it checks if the topic/subject of the email corresponds to a subscriber in its map. If so, it pushes it to the subscriber's queue.

The SubscriberManager is started (i.e. its thread is created) by the Context, whenever needed.

This makes the Subscriber's get_message() method be a simple check for a new message. However, this also adds a get_message_and_wait() util method that waits and returns only when there is a new message.

Overall, this is the initial work to allow for multiple subscribers easily. Some TODOs track various ideas for improvements.

Closes #43