### PR TITLE
Fix reception of multiple new emails

### DIFF
--- a/email/include/email/email/receiver.hpp
+++ b/email/include/email/email/receiver.hpp
@@ -93,6 +93,8 @@ private:
   size_t
   write_callback(void * contents, size_t size, size_t nmemb, void * userp);
 
+  int current_uid_;
+  int next_uid_;
   std::string read_buffer_;
   std::atomic_bool do_shutdown_;
 };

--- a/email/include/email/subscriber.hpp
+++ b/email/include/email/subscriber.hpp
@@ -59,8 +59,8 @@ public:
 
   /// Get a message, waiting until one is available.
   /**
-   * TODO(christophebedard) use a timeout
-   * TODO(christophebedard) sleep a bit
+   * TODO(christophebedard) use a timeout?
+   * TODO(christophebedard) sleep a bit?
    *
    * \return the message
    */

--- a/email/src/example/pub.cpp
+++ b/email/src/example/pub.cpp
@@ -20,9 +20,11 @@
 int main()
 {
   email::init();
-  email::Publisher pub("/my_topic");
-  std::cout << "publishing message" << std::endl;
-  pub.publish("my awesome message!");
+  email::Publisher pub1("/my_topic");
+  email::Publisher pub2("/my_other_topic");
+  std::cout << "publishing messages" << std::endl;
+  pub1.publish("my awesome message!");
+  pub2.publish("my other awesome message!");
   email::shutdown();
   return 0;
 }

--- a/email/src/example/sub.cpp
+++ b/email/src/example/sub.cpp
@@ -20,10 +20,13 @@
 int main()
 {
   email::init();
-  email::Subscriber sub("/my_topic");
+  email::Subscriber sub1("/my_topic");
+  email::Subscriber sub2("/my_other_topic");
   std::cout << "getting message..." << std::endl;
-  auto message = sub.get_message_and_wait();
-  std::cout << "got message: " << message << std::endl;
+  auto message1 = sub1.get_message_and_wait();
+  std::cout << "got message1: " << message1 << std::endl;
+  auto message2 = sub2.get_message_and_wait();
+  std::cout << "got message2: " << message2 << std::endl;
   email::shutdown();
   return 0;
 }


### PR DESCRIPTION
Make sure to keep track of the NEXTUID between calls to EmailReceiver::get_email(). Otherwise it gets updated and we miss any second+ new email.

Also, make sure to clear the read buffer before executing the curl command.