### PR TITLE
Add ServiceClient & ServiceServer

### DIFF
--- a/email/CMakeLists.txt
+++ b/email/CMakeLists.txt
@@ -40,6 +40,9 @@ set(SOURCES
   src/options.cpp
   src/pub_sub.cpp
   src/publisher.cpp
+  src/service.cpp
+  src/service_client.cpp
+  src/service_server.cpp
   src/subscriber.cpp
   src/subscriber_manager.cpp
   src/utils.cpp
@@ -103,6 +106,26 @@ target_link_libraries(sub
 )
 install(TARGETS
   sub
+  DESTINATION lib/${PROJECT_NAME}
+)
+add_executable(service_client
+  example/service_client.cpp
+)
+target_link_libraries(service_client
+  ${PROJECT_NAME}
+)
+install(TARGETS
+  service_client
+  DESTINATION lib/${PROJECT_NAME}
+)
+add_executable(service_server
+  example/service_server.cpp
+)
+target_link_libraries(service_server
+  ${PROJECT_NAME}
+)
+install(TARGETS
+  service_server
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/email/example/service_client.cpp
+++ b/email/example/service_client.cpp
@@ -1,0 +1,33 @@
+// Copyright 2020 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+
+#include "email/init.hpp"
+#include "email/service_client.hpp"
+
+int main()
+{
+  email::init();
+  email::ServiceClient client("/my_service");
+  std::cout << "making request" << std::endl;
+  auto response = client.send_request_and_wait("this is the request!");
+  if (response) {
+    std::cout << "response: " << response.value() << std::endl;
+  } else {
+    std::cout << "no response" << std::endl;
+  }
+  email::shutdown();
+  return 0;
+}

--- a/email/example/service_server.cpp
+++ b/email/example/service_server.cpp
@@ -1,0 +1,32 @@
+// Copyright 2020 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <string>
+
+#include "email/init.hpp"
+#include "email/service_server.hpp"
+
+int main()
+{
+  email::init();
+  email::ServiceServer server("/my_service");
+  std::cout << "getting request" << std::endl;
+  auto request = server.get_request_and_wait();
+  std::cout << "request: " << request << std::endl;
+  std::cout << "sending response" << std::endl;
+  server.send_response("responseeeee!");
+  email::shutdown();
+  return 0;
+}

--- a/email/include/email/pub_sub.hpp
+++ b/email/include/email/pub_sub.hpp
@@ -48,7 +48,7 @@ public:
 protected:
   /// Constructor.
   /**
-   * Validate the topic.
+   * Validates the topic.
    *
    * \param topic the topic
    * \throw `TopicInvalidError` if the topic is invalid

--- a/email/include/email/service.hpp
+++ b/email/include/email/service.hpp
@@ -1,0 +1,76 @@
+// Copyright 2020 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EMAIL__SERVICE_HPP_
+#define EMAIL__SERVICE_HPP_
+
+#include <regex>
+#include <stdexcept>
+#include <string>
+
+namespace email
+{
+
+/// Error when a service name is invalid.
+class ServiceInvalidError : public std::runtime_error
+{
+public:
+  explicit ServiceInvalidError(const std::string & service_name, const std::string & reason)
+  : std::runtime_error("service name invalid (" + reason + "): '" + service_name + "'")
+  {}
+};
+
+/// Abstract service object.
+/**
+ * Abstract class representing common service elements.
+ */
+class ServiceObject
+{
+public:
+  /// Get the service name.
+  /**
+   * \return the service name
+   */
+  std::string
+  get_service_name() const;
+
+protected:
+  /// Constructor.
+  /**
+   * Validates the service name.
+   *
+   * \param service_name the service name
+   * \throw `ServiceInvalidError` if the service name is invalid
+   */
+  explicit ServiceObject(const std::string & service_name);
+  ServiceObject(const ServiceObject &) = delete;
+  virtual ~ServiceObject();
+
+private:
+  /// Validate a service name and throw an error with an explanation if it is not valid.
+  static
+  void
+  validate_service_name(const std::string & service_name);
+
+  /// Regex which matches on a newline, with an optional carriage return before.
+  static const std::regex REGEX_NEWLINE;
+
+  // TODO(christophebedard) extract service name to/inherit from
+  // PubSubObject (rename) to validate the service name itself
+  const std::string service_name_;
+};
+
+}  // namespace email
+
+#endif  // EMAIL__SERVICE_HPP_

--- a/email/include/email/service_client.hpp
+++ b/email/include/email/service_client.hpp
@@ -1,0 +1,62 @@
+// Copyright 2020 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EMAIL__SERVICE_CLIENT_HPP_
+#define EMAIL__SERVICE_CLIENT_HPP_
+
+#include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
+#include <string>
+
+#include "email/publisher.hpp"
+#include "email/service.hpp"
+#include "email/subscriber.hpp"
+#include "email/visibility_control.hpp"
+
+namespace email
+{
+
+/// Service client.
+/**
+ * Sends a request to a service server and gets a response.
+ */
+class ServiceClient : public ServiceObject
+{
+public:
+  /// Constructor.
+  /**
+   * \param service_name the service name
+   */
+  explicit ServiceClient(const std::string & service_name);
+  ServiceClient(const ServiceClient &) = delete;
+  ~ServiceClient();
+
+  /// Send request and get response, waiting for it.
+  /**
+   * TODO(christophebedard) offer async method using SafeQueue for reply
+   * TODO(christophebedard) add timeout for response?
+   *
+   * \param request the request to send
+   * \return the response, or `std::nullopt` if it failed
+   */
+  std::optional<std::string>
+  send_request_and_wait(const std::string & request);
+
+private:
+  Publisher pub_;
+  Subscriber sub_;
+};
+
+}  // namespace email
+
+#endif  // EMAIL__SERVICE_CLIENT_HPP_

--- a/email/include/email/service_server.hpp
+++ b/email/include/email/service_server.hpp
@@ -1,0 +1,90 @@
+// Copyright 2020 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EMAIL__SERVICE_SERVER_HPP_
+#define EMAIL__SERVICE_SERVER_HPP_
+
+#include <chrono>
+#include <memory>
+#include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
+#include <string>
+
+#include "email/email/receiver.hpp"
+#include "email/email/sender.hpp"
+#include "email/safe_queue.hpp"
+#include "email/service.hpp"
+#include "email/subscriber.hpp"
+#include "email/types.hpp"
+#include "email/visibility_control.hpp"
+
+namespace email
+{
+
+/// Service server.
+/**
+ * Gets a request from a client and sends a response.
+ */
+class ServiceServer : public ServiceObject
+{
+public:
+  /// Constructor.
+  /**
+   * \param service_name the service name
+   */
+  explicit ServiceServer(const std::string & service_name);
+  ServiceServer(const ServiceServer &) = delete;
+  ~ServiceServer();
+
+  /// Check if the server has a request.
+  /**
+   * \return true if there is a request, false otherwise
+   */
+  bool
+  has_request();
+
+  /// Get a request if there is one.
+  /**
+   * \return the request, or `std::nullopt` if there is none
+   */
+  std::optional<std::string>
+  get_request();
+
+  /// Get a request, waiting until one is available.
+  /**
+   * TODO(christophebedard) use a timeout?
+   *
+   * \return the request
+   */
+  std::string
+  get_request_and_wait();
+
+  /// Send response.
+  /**
+   * TODO(christophebedard) keep link betwen request & response
+   *
+   * \param response the response
+   */
+  void
+  send_response(const std::string & response);
+
+private:
+  std::shared_ptr<SafeQueue<struct EmailData>> requests_;
+  std::shared_ptr<EmailSender> sender_;
+
+  static constexpr auto WAIT_TIME = std::chrono::milliseconds(1);
+};
+
+}  // namespace email
+
+#endif  // EMAIL__SERVICE_SERVER_HPP_

--- a/email/include/email/subscriber_manager.hpp
+++ b/email/include/email/subscriber_manager.hpp
@@ -57,6 +57,11 @@ public:
     const std::string & topic,
     std::shared_ptr<SafeQueue<std::string>> message_queue);
 
+  void
+  register_service_server(
+    const std::string & service,
+    std::shared_ptr<SafeQueue<struct EmailData>> request_queue);
+
   /// Get status.
   /**
    * \return true if it has been started, false otherwise
@@ -84,6 +89,8 @@ private:
   std::thread thread_;
   std::mutex subscribers_mutex_;
   std::multimap<std::string, std::shared_ptr<SafeQueue<std::string>>> subscribers_;
+  std::mutex services_mutex_;
+  std::multimap<std::string, std::shared_ptr<SafeQueue<struct EmailData>>> services_;
 
   static constexpr auto POLLING_PERIOD = std::chrono::milliseconds(1);
 };

--- a/email/include/email/types.hpp
+++ b/email/include/email/types.hpp
@@ -114,8 +114,10 @@ struct EmailContent
 /// Raw email data with headers.
 struct EmailData
 {
-  /// Message ID.
+  /// Message-ID header value.
   std::string message_id;
+  /// In-Reply-To header value.
+  std::string in_reply_to;
   /// Origin email.
   std::string from;
   /// Recipients of the email.
@@ -125,10 +127,15 @@ struct EmailData
   /// Constructor.
   EmailData(
     const std::string & message_id_,
+    const std::string & in_reply_to_,
     const std::string & from_,
     const struct EmailRecipients & recipients_,
     const struct EmailContent & content_)
-  : message_id(message_id_), from(from_), recipients(recipients_), content(content_)
+  : message_id(message_id_),
+    in_reply_to(in_reply_to_),
+    from(from_),
+    recipients(recipients_),
+    content(content_)
   {}
   /// Copy constructor.
   EmailData(const EmailData &) = default;

--- a/email/src/email/response_utils.cpp
+++ b/email/src/email/response_utils.cpp
@@ -31,6 +31,7 @@ static const std::regex REGEX_BCC(R"(Bcc: (.*)\r?\n)");
 static const std::regex REGEX_BODY(R"((?:\r?\n){2}((?:.*\n*)*)(?:\r?\n)?)");
 static const std::regex REGEX_CC(R"(Cc: (.*)\r?\n)");
 static const std::regex REGEX_FROM(R"(From: (.*)\r?\n)");
+static const std::regex REGEX_IN_REPLY_TO(R"(In-Reply-To: (.*)\r?\n)");
 static const std::regex REGEX_MESSAGE_ID(R"(Message-ID: (.*)\r?\n)");
 static const std::regex REGEX_NEXTUID(
   R"(.*OK \[UIDNEXT (.*)\] Predicted next UID.*)",
@@ -66,9 +67,10 @@ std::optional<struct EmailData>
 get_email_data_from_response(const std::string & curl_result)
 {
   auto match_from = get_first_match_group(curl_result, REGEX_FROM);
+  auto match_in_reply_to = get_first_match_group(curl_result, REGEX_IN_REPLY_TO);
   auto match_message_id = get_first_match_group(curl_result, REGEX_MESSAGE_ID);
   auto content_opt = get_email_content_from_response(curl_result);
-  if (!match_from || !match_message_id || !content_opt) {
+  if (!match_from || !match_in_reply_to || !match_message_id || !content_opt) {
     return std::nullopt;
   }
   auto match_to = get_first_match_group(curl_result, REGEX_TO);
@@ -83,6 +85,7 @@ get_email_data_from_response(const std::string & curl_result)
     split_email_list(match_bcc.value(), true));
   struct EmailData email_data(
     match_message_id.value(),
+    match_in_reply_to.value(),
     match_from.value(),
     recipients,
     content_opt.value());

--- a/email/src/service.cpp
+++ b/email/src/service.cpp
@@ -1,0 +1,50 @@
+// Copyright 2020 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <regex>
+#include <string>
+
+#include "email/service.hpp"
+
+namespace email
+{
+
+ServiceObject::ServiceObject(const std::string & service_name)
+: service_name_(service_name)
+{
+  validate_service_name(service_name);
+}
+
+ServiceObject::~ServiceObject() {}
+
+std::string
+ServiceObject::get_service_name() const
+{
+  return service_name_;
+}
+
+void
+ServiceObject::validate_service_name(const std::string & service_name)
+{
+  if (service_name.empty()) {
+    throw ServiceInvalidError(service_name, "empty");
+  }
+  if (std::regex_match(service_name, ServiceObject::REGEX_NEWLINE)) {
+    throw ServiceInvalidError(service_name, "newline");
+  }
+}
+
+const std::regex ServiceObject::REGEX_NEWLINE(".*[\r]?\n.*", std::regex::extended);
+
+}  // namespace email

--- a/email/src/service_client.cpp
+++ b/email/src/service_client.cpp
@@ -1,0 +1,41 @@
+// Copyright 2020 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
+#include <string>
+
+#include "email/publisher.hpp"
+#include "email/service_client.hpp"
+#include "email/subscriber.hpp"
+
+namespace email
+{
+
+ServiceClient::ServiceClient(const std::string & service_name)
+: ServiceObject(service_name),
+  pub_(get_service_name()),
+  sub_(get_service_name())
+{}
+
+ServiceClient::~ServiceClient() {}
+
+std::optional<std::string>
+ServiceClient::send_request_and_wait(const std::string & request)
+{
+  pub_.publish(request);
+  return sub_.get_message_and_wait();
+}
+
+}  // namespace email

--- a/email/src/service_server.cpp
+++ b/email/src/service_server.cpp
@@ -1,0 +1,83 @@
+// Copyright 2020 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+#include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
+#include <string>
+#include <thread>
+
+#include "email/context.hpp"
+#include "email/email/receiver.hpp"
+#include "email/email/sender.hpp"
+#include "email/safe_queue.hpp"
+#include "email/service.hpp"
+#include "email/service_server.hpp"
+#include "email/types.hpp"
+
+namespace email
+{
+
+ServiceServer::ServiceServer(const std::string & service_name)
+: ServiceObject(service_name),
+  requests_(std::make_shared<SafeQueue<struct EmailData>>()),
+  sender_(get_global_context()->get_sender())
+{
+  // Register with manager
+  get_global_context()->get_subscriber_manager()->register_service_server(
+    get_service_name(), requests_);
+}
+
+ServiceServer::~ServiceServer() {}
+
+bool
+ServiceServer::has_request()
+{
+  return !requests_->empty();
+}
+
+std::optional<std::string>
+ServiceServer::get_request()
+{
+  if (!has_request()) {
+    return std::nullopt;
+  }
+  return requests_->front().content.body;
+}
+
+std::string
+ServiceServer::get_request_and_wait()
+{
+  while (requests_->empty()) {
+    std::this_thread::sleep_for(WAIT_TIME);
+  }
+  return requests_->front().content.body;
+}
+
+void
+ServiceServer::send_response(const std::string & response)
+{
+  // TODO(christophebedard) make this better
+  if (!has_request()) {
+    std::cerr << "no request to reply to" << std::endl;
+    return;
+  }
+  auto request = requests_->dequeue();
+  struct EmailContent response_content {get_service_name(), response};
+  if (!sender_->reply(response_content, request)) {
+    std::cerr << "send_response() failed" << std::endl;
+  }
+}
+
+}  // namespace email


### PR DESCRIPTION
Initial implementation; improvements to follow.

The ServiceClient has a Publisher and a Subscriber. It sends its request using its Publisher, and gets the response using its Subscriber.

The ServiceServer has a Publisher and a special requests queue. Its Publisher is used to send back its response as an email reply. It registers its requests queue with the SubscriberManager (to be refactored) in order to keep the whole EmailData struct, not just the email body.

Closes #52