### PR TITLE
Only shut down context's object's if they have been initalized

### DIFF
--- a/email/include/email/context.hpp
+++ b/email/include/email/context.hpp
@@ -149,6 +149,8 @@ public:
 private:
   std::shared_ptr<Options> options_;
   bool is_valid_;
+  mutable bool is_receiver_init_;
+  mutable bool is_subscriber_manager_init_;
 };
 
 /// Get the global context.

--- a/email/include/email/email/receiver.hpp
+++ b/email/include/email/email/receiver.hpp
@@ -49,6 +49,10 @@ public:
   EmailReceiver & operator=(const EmailReceiver &) = delete;
   virtual ~EmailReceiver();
 
+  /// Shut down.
+  /**
+   * Stops any currently-running internal polling loop.
+   */
   void
   shutdown();
 

--- a/email/src/context.cpp
+++ b/email/src/context.cpp
@@ -32,7 +32,9 @@ get_global_context()
 
 Context::Context()
 : options_(nullptr),
-  is_valid_(false)
+  is_valid_(false),
+  is_receiver_init_(false),
+  is_subscriber_manager_init_(false)
 {}
 
 Context::~Context()
@@ -77,8 +79,13 @@ Context::shutdown()
   if (!is_valid()) {
     return false;
   }
-  // TODO(christophebedard) don't call if it hasn't been started?
-  get_subscriber_manager()->shutdown();
+  // Only call shutdown() if they have been init, otherwise they will get initialized
+  if (is_receiver_init_) {
+    get_receiver()->shutdown();
+  }
+  if (is_subscriber_manager_init_) {
+    get_subscriber_manager()->shutdown();
+  }
   return true;
 }
 
@@ -108,6 +115,7 @@ Context::get_receiver() const
     options_->debug());
   if (!receiver->is_valid()) {
     receiver->init();
+    is_receiver_init_ = true;
   }
   return receiver;
 }
@@ -139,6 +147,7 @@ Context::get_subscriber_manager() const
     options_->debug());
   if (!manager->has_started()) {
     manager->start();
+    is_subscriber_manager_init_ = true;
   }
   return manager;
 }

--- a/email/src/subscriber_manager.cpp
+++ b/email/src/subscriber_manager.cpp
@@ -79,8 +79,10 @@ void
 SubscriberManager::shutdown()
 {
   receiver_->shutdown();
-  do_shutdown_ = true;
-  thread_.join();
+  if (has_started()) {
+    do_shutdown_ = true;
+    thread_.join();
+  }
 }
 
 void


### PR DESCRIPTION
Otherwise, calling shutdown() on them will initialize them uselessly before shuting them down.