### PR TITLE
Use logger

### DIFF
--- a/email/CMakeLists.txt
+++ b/email/CMakeLists.txt
@@ -15,6 +15,8 @@ endif()
 
 find_package(ament_cmake_ros REQUIRED)
 find_package(rcpputils REQUIRED)
+find_package(spdlog_vendor REQUIRED)
+find_package(spdlog REQUIRED)
 
 set(CURL_USE_VENDOR FALSE)
 find_package(CURL)
@@ -38,6 +40,7 @@ set(SOURCES
   src/email/response_utils.cpp
   src/email/sender.cpp
   src/init.cpp
+  src/log.cpp
   src/options.cpp
   src/pub_sub.cpp
   src/publisher.cpp
@@ -56,7 +59,8 @@ if(CURL_USE_VENDOR)
 else()
   target_link_libraries(${PROJECT_NAME} ${CURL_LIBRARIES})
 endif()
-ament_target_dependencies(${PROJECT_NAME} rcpputils)
+ament_target_dependencies(${PROJECT_NAME} rcpputils spdlog)
+target_link_libraries(${PROJECT_NAME} spdlog::spdlog)
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>"

--- a/email/example/receive.cpp
+++ b/email/example/receive.cpp
@@ -26,7 +26,7 @@ int main(int argc, char ** argv)
 {
   email::init(argc, argv);
   std::shared_ptr<email::Options> options = email::get_global_context()->get_options();
-  email::EmailReceiver receiver(options->get_user_info(), options->debug());
+  email::EmailReceiver receiver(options->get_user_info(), options->curl_verbose());
   if (!receiver.init()) {
     return 1;
   }

--- a/email/example/send.cpp
+++ b/email/example/send.cpp
@@ -28,7 +28,7 @@ int main(int argc, char ** argv)
   email::EmailSender sender(
     options->get_user_info(),
     options->get_recipients(),
-    options->debug());
+    options->curl_verbose());
   if (!sender.init()) {
     return 1;
   }

--- a/email/include/email/context.hpp
+++ b/email/include/email/context.hpp
@@ -23,6 +23,7 @@
 #include "email/email/polling_manager.hpp"
 #include "email/email/receiver.hpp"
 #include "email/email/sender.hpp"
+#include "email/log.hpp"
 #include "email/options.hpp"
 #include "email/service_handler.hpp"
 #include "email/subscription_handler.hpp"
@@ -165,6 +166,11 @@ public:
   get_service_handler() const;
 
 private:
+  /// Perform common init tasks.
+  void
+  init_common();
+
+  std::shared_ptr<Logger> logger_;
   std::shared_ptr<Options> options_;
   bool is_valid_;
   mutable bool is_receiver_init_;

--- a/email/include/email/curl/context.hpp
+++ b/email/include/email/curl/context.hpp
@@ -17,8 +17,10 @@
 
 #include <curl/curl.h>
 
+#include <memory>
 #include <string>
 
+#include "email/log.hpp"
 #include "email/types.hpp"
 #include "email/utils.hpp"
 
@@ -37,12 +39,12 @@ public:
   /**
    * \param connection_info the connection information
    * \param protocol_info the protocol information
-   * \param debug the debug status
+   * \param curl_verbose the curl verbose status
    */
   explicit CurlContext(
     const struct ConnectionInfo & connection_info,
     const struct ProtocolInfo & protocol_info,
-    const bool debug);
+    const bool curl_verbose);
   CurlContext(const CurlContext &) = delete;
   CurlContext & operator=(const CurlContext &) = delete;
   ~CurlContext();
@@ -91,10 +93,11 @@ public:
   get_connection_info() const;
 
 private:
+  std::shared_ptr<Logger> logger_;
   CURL * handle_;
   const struct ConnectionInfo connection_info_;
   const std::string full_url_;
-  bool debug_;
+  bool curl_verbose_;
 };
 
 }  // namespace email

--- a/email/include/email/curl/executor.hpp
+++ b/email/include/email/curl/executor.hpp
@@ -47,12 +47,12 @@ protected:
   /**
    * \param connection_info the connection info
    * \param protocol_info the protocol info
-   * \param debug the debug status
+   * \param curl_verbose the curl verbose status
    */
   explicit CurlExecutor(
     const struct ConnectionInfo & connection_info,
     const struct ProtocolInfo & protocol_info,
-    const bool debug);
+    const bool curl_verbose);
   CurlExecutor(const CurlExecutor &) = delete;
   CurlExecutor & operator=(const CurlExecutor &) = delete;
   virtual ~CurlExecutor();
@@ -68,7 +68,6 @@ protected:
   init_options() = 0;
 
   CurlContext context_;
-  const bool debug_;
 
 private:
   bool is_valid_;

--- a/email/include/email/email/polling_manager.hpp
+++ b/email/include/email/email/polling_manager.hpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "email/email/receiver.hpp"
+#include "email/log.hpp"
 #include "email/types.hpp"
 #include "email/visibility_control.hpp"
 
@@ -41,9 +42,8 @@ public:
   /// Constructor.
   /**
    * \param receiver the email receiver to use for getting emails
-   * \param debug the debug status
    */
-  explicit PollingManager(std::shared_ptr<EmailReceiver> receiver, const bool debug);
+  explicit PollingManager(std::shared_ptr<EmailReceiver> receiver);
   PollingManager(const PollingManager &) = delete;
   PollingManager & operator=(const PollingManager &) = delete;
   ~PollingManager();
@@ -81,12 +81,12 @@ private:
   poll_thread();
 
   std::shared_ptr<EmailReceiver> receiver_;
-  bool debug_;
   bool has_started_;
   std::atomic_bool do_shutdown_;
   std::thread thread_;
   std::mutex handlers_mutex_;
   std::vector<HandlerFunction> handlers_;
+  std::shared_ptr<Logger> logger_;
 
   static constexpr auto POLLING_PERIOD = std::chrono::milliseconds(1);
 };

--- a/email/include/email/email/receiver.hpp
+++ b/email/include/email/email/receiver.hpp
@@ -18,13 +18,13 @@
 #include <curl/curl.h>
 
 #include <atomic>
-#include <iostream>
 #include <memory>
 #include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
 #include <regex>
 #include <string>
 
 #include "email/curl/executor.hpp"
+#include "email/log.hpp"
 #include "email/types.hpp"
 
 namespace email
@@ -40,11 +40,11 @@ public:
   /// Constructor.
   /**
    * \param user_info the user information for receiving emails
-   * \param debug the debug status
+   * \param curl_verbose the curl verbose status
    */
   explicit EmailReceiver(
     UserInfo::SharedPtrConst user_info,
-    const bool debug);
+    const bool curl_verbose);
   EmailReceiver(const EmailReceiver &) = delete;
   EmailReceiver & operator=(const EmailReceiver &) = delete;
   virtual ~EmailReceiver();
@@ -98,6 +98,7 @@ private:
   size_t
   write_callback(void * contents, size_t size, size_t nmemb, void * userp);
 
+  std::shared_ptr<Logger> logger_;
   int current_uid_;
   int next_uid_;
   std::string read_buffer_;

--- a/email/include/email/email/sender.hpp
+++ b/email/include/email/email/sender.hpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "email/curl/executor.hpp"
+#include "email/log.hpp"
 #include "email/types.hpp"
 #include "email/visibility_control.hpp"
 
@@ -39,12 +40,12 @@ public:
   /**
    * \param user_info the user information for sending emails
    * \param recipients the email recipients
-   * \param debug the debug status
+   * \param curl_verbose the curl verbose status
    */
   explicit EmailSender(
     UserInfo::SharedPtrConst user_info,
     EmailRecipients::SharedPtrConst recipients,
-    const bool debug);
+    const bool curl_verbose);
   EmailSender(const EmailSender &) = delete;
   EmailSender & operator=(const EmailSender &) = delete;
   virtual ~EmailSender();
@@ -92,6 +93,7 @@ private:
     int lines_read;
   };
 
+  std::shared_ptr<Logger> logger_;
   EmailRecipients::SharedPtrConst recipients_;
   struct curl_slist * recipients_list_;
   struct UploadData upload_ctx_;

--- a/email/include/email/log.hpp
+++ b/email/include/email/log.hpp
@@ -1,0 +1,81 @@
+// Copyright 2020 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EMAIL__LOG_HPP_
+#define EMAIL__LOG_HPP_
+
+#include <memory>
+#include <string>
+
+#include "spdlog/spdlog.h"
+
+namespace email
+{
+
+/// Abstract away the logger implementation.
+using Logger = spdlog::logger;
+
+namespace log
+{
+
+/// Initialize logging.
+void
+init();
+
+/// Logging level.
+enum Level
+{
+  debug,
+  info,
+  warn,
+  error,
+  fatal,
+  off
+};
+
+/// Set global logging level.
+/**
+ * \param level the logging level
+ */
+void
+set_level(Level level);
+
+/// Set global logging level from environment variable value.
+void
+set_level_from_env();
+
+/// Create logger from the root logger.
+/**
+ * Uses sink(s) and log level from the root logger.
+ *
+ * \param name the name of the logger
+ * \return the logger
+ */
+std::shared_ptr<Logger>
+create(const std::string & name);
+
+/// Get an existing logger or create it from the root logger.
+/**
+ * Useful for sharing a logger.
+ *
+ * \param name the name of the logger
+ * \return the logger
+ */
+std::shared_ptr<Logger>
+get_or_create(const std::string & name);
+
+}  // namespace log
+}  // namespace email
+
+#endif  // EMAIL__LOG_HPP_

--- a/email/include/email/options.hpp
+++ b/email/include/email/options.hpp
@@ -38,12 +38,12 @@ public:
    *
    * \param user_info the user info
    * \param recipients the recipients
-   * \param debug the debug status
+   * \param curl_verbose the curl verbose status
    */
   Options(
     UserInfo::SharedPtrConst user_info,
     EmailRecipients::SharedPtrConst recipients,
-    bool debug);
+    bool curl_verbose);
   ~Options();
 
   /// Get user information data.
@@ -60,12 +60,12 @@ public:
   EmailRecipients::SharedPtrConst
   get_recipients() const;
 
-  /// Get the debug status.
+  /// Get the curl verbose status.
   /**
-   * \return true if debug, false otherwise
+   * \return true if verbose, false otherwise
    */
   bool
-  debug() const;
+  curl_verbose() const;
 
   /// Parse options from CLI arguments.
   /**
@@ -88,14 +88,14 @@ public:
 private:
   UserInfo::SharedPtrConst user_info_;
   EmailRecipients::SharedPtrConst recipients_;
-  bool debug_;
+  bool curl_verbose_;
 
   static const std::regex REGEX_CONFIG_FILE;
-  static constexpr const char * ENV_VAR_DEBUG = "EMAIL_DEBUG";
+  static constexpr const char * ENV_VAR_CURL_VERBOSE = "EMAIL_CURL_VERBOSE";
   static constexpr const char * ENV_VAR_CONFIG_FILE = "EMAIL_CONFIG_FILE";
   static constexpr const char * ENV_VAR_CONFIG_FILE_DEFAULT = "email.yml";
   static constexpr const char * USAGE_CLI_ARGS =
-    "usage: HOST_SMTP HOST_IMAP EMAIL PASSWORD EMAIL_TO [-d|--debug]";
+    "usage: HOST_SMTP HOST_IMAP EMAIL PASSWORD EMAIL_TO [-v|--curl-verbose]";
 };
 
 }  // namespace email

--- a/email/include/email/publisher.hpp
+++ b/email/include/email/publisher.hpp
@@ -19,6 +19,7 @@
 #include <string>
 
 #include "email/email/sender.hpp"
+#include "email/log.hpp"
 #include "email/pub_sub.hpp"
 #include "email/types.hpp"
 #include "email/visibility_control.hpp"
@@ -50,6 +51,7 @@ public:
   publish(const std::string & message);
 
 private:
+  std::shared_ptr<Logger> logger_;
   std::shared_ptr<EmailSender> sender_;
 };
 

--- a/email/include/email/service_handler.hpp
+++ b/email/include/email/service_handler.hpp
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "email/safe_queue.hpp"
+#include "email/log.hpp"
 #include "email/types.hpp"
 #include "email/visibility_control.hpp"
 
@@ -35,10 +36,7 @@ class ServiceHandler
 {
 public:
   /// Constructor.
-  /**
-   * \param debug the debug status
-   */
-  explicit ServiceHandler(const bool debug);
+  ServiceHandler();
   ServiceHandler(const ServiceHandler &) = delete;
   ServiceHandler & operator=(const ServiceHandler &) = delete;
   ~ServiceHandler();
@@ -63,7 +61,7 @@ public:
   handle(const struct EmailData & data);
 
 private:
-  bool debug_;
+  std::shared_ptr<Logger> logger_;
   std::mutex services_mutex_;
   std::multimap<std::string, std::shared_ptr<SafeQueue<struct EmailData>>> services_;
 };

--- a/email/include/email/service_server.hpp
+++ b/email/include/email/service_server.hpp
@@ -22,6 +22,7 @@
 
 #include "email/email/receiver.hpp"
 #include "email/email/sender.hpp"
+#include "email/log.hpp"
 #include "email/safe_queue.hpp"
 #include "email/service.hpp"
 #include "email/subscriber.hpp"
@@ -80,6 +81,7 @@ public:
   send_response(const std::string & response);
 
 private:
+  std::shared_ptr<Logger> logger_;
   std::shared_ptr<SafeQueue<struct EmailData>> requests_;
   std::shared_ptr<EmailSender> sender_;
 

--- a/email/include/email/subscription_handler.hpp
+++ b/email/include/email/subscription_handler.hpp
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "email/safe_queue.hpp"
+#include "email/log.hpp"
 #include "email/types.hpp"
 #include "email/visibility_control.hpp"
 
@@ -35,10 +36,7 @@ class SubscriptionHandler
 {
 public:
   /// Constructor.
-  /**
-   * \param debug the debug status
-   */
-  explicit SubscriptionHandler(const bool debug);
+  SubscriptionHandler();
   SubscriptionHandler(const SubscriptionHandler &) = delete;
   SubscriptionHandler & operator=(const SubscriptionHandler &) = delete;
   ~SubscriptionHandler();
@@ -63,7 +61,7 @@ public:
   handle(const struct EmailData & data);
 
 private:
-  bool debug_;
+  std::shared_ptr<Logger> logger_;
   std::mutex subscribers_mutex_;
   std::multimap<std::string, std::shared_ptr<SafeQueue<std::string>>> subscribers_;
 };

--- a/email/package.xml
+++ b/email/package.xml
@@ -10,9 +10,15 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <build_depend>spdlog_vendor</build_depend>
+  <build_depend>spdlog</build_depend>
+
   <!-- Only actually used if libcurl isn't found on the system -->
   <depend>libcurl_vendor</depend>
   <depend>rcpputils</depend>
+
+  <exec_depend>spdlog_vendor</exec_depend>
+  <exec_depend>spdlog</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/email/src/curl/executor.cpp
+++ b/email/src/curl/executor.cpp
@@ -22,9 +22,8 @@ namespace email
 CurlExecutor::CurlExecutor(
   const struct ConnectionInfo & connection_info,
   const struct ProtocolInfo & protocol_info,
-  const bool debug)
-: context_(connection_info, protocol_info, debug),
-  debug_(debug),
+  const bool curl_verbose)
+: context_(connection_info, protocol_info, curl_verbose),
   is_valid_(false)
 {}
 

--- a/email/src/log.cpp
+++ b/email/src/log.cpp
@@ -1,0 +1,129 @@
+// Copyright 2020 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "spdlog/sinks/stdout_color_sinks.h"
+#include "spdlog/spdlog.h"
+
+#include "email/log.hpp"
+#include "email/utils.hpp"
+
+namespace email
+{
+namespace log
+{
+
+static std::mutex logger_mutex;
+static std::shared_ptr<spdlog::logger> root_logger = nullptr;
+static constexpr const char * ENV_VAR_LOG_LEVEL = "EMAIL_LOG_LEVEL";
+static constexpr const char * ENV_VAR_LOG_LEVEL_DEFAULT = "info";
+
+static
+spdlog::level::level_enum
+level_to_spdlog(const Level & level)
+{
+  switch (level) {
+    case debug:
+      return spdlog::level::level_enum::debug;
+    case info:
+      return spdlog::level::level_enum::info;
+    case error:
+      return spdlog::level::level_enum::err;
+    case warn:
+      return spdlog::level::level_enum::warn;
+    case fatal:
+      return spdlog::level::level_enum::critical;
+    case off:  // fallthrough
+    default:
+      return spdlog::level::level_enum::off;
+  }
+}
+
+static
+spdlog::level::level_enum
+string_level_to_spdlog(const std::string & level)
+{
+  if ("debug" == level) {
+    return spdlog::level::level_enum::debug;
+  }
+  if ("info" == level) {
+    return spdlog::level::level_enum::info;
+  }
+  if ("warn" == level) {
+    return spdlog::level::level_enum::warn;
+  }
+  if ("error" == level) {
+    return spdlog::level::level_enum::err;
+  }
+  if ("fatal" == level) {
+    return spdlog::level::level_enum::critical;
+  }
+  return spdlog::level::level_enum::off;
+}
+
+void
+init()
+{
+  std::lock_guard<std::mutex> lock(logger_mutex);
+  if (nullptr != root_logger) {
+    return;
+  }
+  root_logger = spdlog::stdout_color_mt("root");
+}
+
+void
+set_level(const Level & level)
+{
+  std::lock_guard<std::mutex> lock(logger_mutex);
+  root_logger->set_level(level_to_spdlog(level));
+}
+
+void
+set_level_from_env()
+{
+  const std::string env_log_level = utils::get_env_var_or_default(
+    ENV_VAR_LOG_LEVEL,
+    ENV_VAR_LOG_LEVEL_DEFAULT);
+  {
+    std::lock_guard<std::mutex> lock(logger_mutex);
+    root_logger->set_level(string_level_to_spdlog(env_log_level));
+  }
+}
+
+std::shared_ptr<spdlog::logger>
+create(const std::string & name)
+{
+  std::lock_guard<std::mutex> lock(logger_mutex);
+  auto & sinks = root_logger->sinks();
+  auto logger = std::make_shared<spdlog::logger>(name, sinks.begin(), sinks.end());
+  logger->set_level(root_logger->level());
+  spdlog::register_logger(logger);
+  return logger;
+}
+
+std::shared_ptr<Logger>
+get_or_create(const std::string & name)
+{
+  std::shared_ptr<spdlog::logger> logger = spdlog::get(name);
+  if (nullptr == logger) {
+    logger = create(name);
+  }
+  return logger;
+}
+
+}  // namespace log
+}  // namespace email

--- a/email/src/options.cpp
+++ b/email/src/options.cpp
@@ -29,10 +29,10 @@ namespace email
 Options::Options(
   UserInfo::SharedPtrConst user_info,
   EmailRecipients::SharedPtrConst recipients,
-  bool debug)
+  bool curl_verbose)
 : user_info_(user_info),
   recipients_(recipients),
-  debug_(debug)
+  curl_verbose_(curl_verbose)
 {}
 
 Options::~Options() {}
@@ -50,9 +50,9 @@ Options::get_recipients() const
 }
 
 bool
-Options::debug() const
+Options::curl_verbose() const
 {
-  return debug_;
+  return curl_verbose_;
 }
 
 std::optional<std::shared_ptr<Options>>
@@ -69,17 +69,17 @@ Options::parse_options_from_args(int argc, char const * const argv[])
     std::string(argv[4]));
   EmailRecipients::SharedPtrConst recipients =
     std::make_shared<const struct EmailRecipients>(std::string(argv[5]));
-  bool debug = false;
+  bool curl_verbose = false;
   if (7 == argc) {
     const std::string argv6 = std::string(argv[6]);
-    if ("-d" == argv6 || "--debug" == argv6) {
-      debug = true;
+    if ("-v" == argv6 || "--curl-verbose" == argv6) {
+      curl_verbose = true;
     }
   }
   return std::make_shared<Options>(
     user_info,
     recipients,
-    debug);
+    curl_verbose);
 }
 
 std::optional<std::shared_ptr<Options>>
@@ -118,11 +118,11 @@ Options::parse_options_from_file()
     utils::split_email_list(matches[5].str()),
     utils::split_email_list(matches[6].str()),
     utils::split_email_list(matches[7].str()));
-  const std::string debug_env_var = utils::get_env_var(Options::ENV_VAR_DEBUG);
+  const std::string curl_verbose_env_var = utils::get_env_var(Options::ENV_VAR_CURL_VERBOSE);
   return std::make_shared<Options>(
     user_info,
     recipients,
-    !debug_env_var.empty());
+    !curl_verbose_env_var.empty());
 }
 
 // See: https://regexr.com/580va

--- a/email/src/publisher.cpp
+++ b/email/src/publisher.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
 #include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
 #include <string>
 
 #include "email/context.hpp"
 #include "email/email/sender.hpp"
+#include "email/log.hpp"
 #include "email/pub_sub.hpp"
 #include "email/publisher.hpp"
 #include "email/types.hpp"
@@ -27,6 +27,7 @@ namespace email
 
 Publisher::Publisher(const std::string & topic_name)
 : PubSubObject(topic_name),
+  logger_(log::create("Publisher::" + topic_name)),
   sender_(get_global_context()->get_sender())
 {}
 
@@ -37,7 +38,7 @@ Publisher::publish(const std::string & message)
 {
   struct EmailContent content {get_topic_name(), message};
   if (!sender_->send(content)) {
-    std::cerr << "publish() failed" << std::endl;
+    logger_->error("publish() failed");
   }
 }
 

--- a/email/src/service_client.cpp
+++ b/email/src/service_client.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
 #include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
 #include <string>
 

--- a/email/src/service_handler.cpp
+++ b/email/src/service_handler.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -20,6 +19,7 @@
 
 #include "email/context.hpp"
 #include "email/email/polling_manager.hpp"
+#include "email/log.hpp"
 #include "email/safe_queue.hpp"
 #include "email/service_handler.hpp"
 #include "email/types.hpp"
@@ -27,8 +27,8 @@
 namespace email
 {
 
-ServiceHandler::ServiceHandler(const bool debug)
-: debug_(debug),
+ServiceHandler::ServiceHandler()
+: logger_(log::create("ServiceHandler")),
   services_mutex_(),
   services_()
 {
@@ -38,6 +38,7 @@ ServiceHandler::ServiceHandler(const bool debug)
       &ServiceHandler::handle,
       this,
       std::placeholders::_1));
+  logger_->debug("initialized");
 }
 
 ServiceHandler::~ServiceHandler() {}

--- a/email/src/service_server.cpp
+++ b/email/src/service_server.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
 #include <memory>
 #include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
 #include <string>
@@ -20,6 +19,7 @@
 
 #include "email/context.hpp"
 #include "email/email/sender.hpp"
+#include "email/log.hpp"
 #include "email/safe_queue.hpp"
 #include "email/service.hpp"
 #include "email/service_handler.hpp"
@@ -31,6 +31,7 @@ namespace email
 
 ServiceServer::ServiceServer(const std::string & service_name)
 : ServiceObject(service_name),
+  logger_(log::create("ServiceServer::" + service_name)),
   requests_(std::make_shared<SafeQueue<struct EmailData>>()),
   sender_(get_global_context()->get_sender())
 {
@@ -70,13 +71,13 @@ ServiceServer::send_response(const std::string & response)
 {
   // TODO(christophebedard) make this better
   if (!has_request()) {
-    std::cerr << "no request to reply to" << std::endl;
+    logger_->warn("no request to reply to");
     return;
   }
   auto request = requests_->dequeue();
   struct EmailContent response_content {get_service_name(), response};
   if (!sender_->reply(response_content, request)) {
-    std::cerr << "send_response() failed" << std::endl;
+    logger_->error("send_response() failed");
   }
 }
 


### PR DESCRIPTION
This adds logging using spdlog. A "log" header provides a couple functions to abstract away the actual logger implementation. The root logger is initialized as part of the context initialization.

This replaces the "debug" flag/option with a logger in most places, but keeps the flag and renames it to "curl verbose" to control the verbose mode for curl separately, e.g. with the "EMAIL_CURL_VERBOSE" environment variable.

The logging level defaults to "info" and can be set using the "EMAIL_LOG_LEVEL" environment variable, which simply maps to the spdlog logging levels, e.g. `EMAIL_LOG_LEVEL=debug ./app`.

Curently, it only prints logs to stdout.

Closes #64