### PR TITLE
Add sample config file

### DIFF
--- a/email/email.yml
+++ b/email/email.yml
@@ -1,0 +1,10 @@
+email:
+  user:
+    url-smtp:
+    url-imap:
+    username:
+    password:
+  recipients:
+    to:
+    cc:
+    bcc:


### PR DESCRIPTION
This adds a sample, empty config file that users can just copy and fill out with their info.

Otherwise the format is deep somewhere in the code.

Closes #74