### PR TITLE
Allow writing logs to file using EMAIL_LOG_FILE env var

### DIFF
--- a/email/include/email/log.hpp
+++ b/email/include/email/log.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Christophe Bedard
+// Copyright 2020-2021 Christophe Bedard
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/email/src/log.cpp
+++ b/email/src/log.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Christophe Bedard
+// Copyright 2020-2021 Christophe Bedard
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Closes #90

This allows writing logs to a file specified using the `EMAIL_LOG_FILE` environment variable. All logs are written to the file, no matter the logging level set using `EMAIL_LOG_LEVEL`.