### PR TITLE
Allow providing a custom service request ID when making a request

### DIFF
--- a/email/include/email/service_client.hpp
+++ b/email/include/email/service_client.hpp
@@ -45,6 +45,16 @@ public:
   ServiceClient & operator=(const ServiceClient &) = delete;
   ~ServiceClient();
 
+  /// Send request with specific ID.
+  /**
+   * For asynchronous sending of a request.
+   *
+   * \param request the request
+   * \param request_id the request ID; to use for getting the corresponding response
+   */
+  void
+  send_request(const std::string & request, const uint32_t request_id);
+
   /// Send request.
   /**
    * For asynchronous sending of a request.

--- a/email/src/service_client.cpp
+++ b/email/src/service_client.cpp
@@ -41,16 +41,22 @@ ServiceClient::ServiceClient(const std::string & service_name)
 
 ServiceClient::~ServiceClient() {}
 
+void
+ServiceClient::send_request(const std::string & request, const uint32_t request_id)
+{
+  const EmailHeaders request_id_header = {
+    {std::string(ServiceHandler::HEADER_REQUEST_ID), std::to_string(request_id)}};
+  pub_.publish(request, request_id_header);
+}
+
 uint32_t
 ServiceClient::send_request(const std::string & request)
 {
-  static uint32_t request_id = 0;
-  const uint32_t next_id = request_id++;
-  logger_->debug("creating request with ID: " + std::to_string(next_id));
-  const EmailHeaders request_id_header = {
-    {std::string(ServiceHandler::HEADER_REQUEST_ID), std::to_string(next_id)}};
-  pub_.publish(request, request_id_header);
-  return next_id;
+  static uint32_t request_id_counter = 0u;
+  const uint32_t request_id = request_id_counter++;
+  logger_->debug("creating request with ID: " + std::to_string(request_id));
+  send_request(request, request_id);
+  return request_id;
 }
 
 bool


### PR DESCRIPTION
As mentioned here https://github.com/christophebedard/rmw_email/issues/73#issuecomment-708721136, the ID might have to be generated in the `rmw` implementation layer itself and provided to the middleware.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>