### PR TITLE
Properly install email include directory

### DIFF
--- a/email/CMakeLists.txt
+++ b/email/CMakeLists.txt
@@ -3,7 +3,6 @@ project(email)
 
 # Default to C++17 for std::optional
 if(NOT CMAKE_CXX_STANDARD)
-  # set(CMAKE_CXX_STANDARD 14)
   set(CMAKE_CXX_STANDARD 17)
 endif()
 


### PR DESCRIPTION
Allows building a package that uses `email` and its `include/` directory.