### PR TITLE
Add CI parameters for OS and build type (source/binary)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,27 +7,30 @@ on:
 jobs:
   test:
     name: "Build and test"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            build-type: binary
+          - os: ubuntu-latest
+            build-type: source
     steps:
     - uses: actions/checkout@v2
     - uses: ros-tooling/setup-ros@master
+      with:
+        required-ros-distributions: ${{ matrix.build-type == 'binary' && 'rolling' || '' }}
     - uses: ros-tooling/action-ros-ci@master
       with:
         package-name: email
         target-ros2-distro: rolling
-        vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+        vcs-repo-file-url: ${{ matrix.build-type == 'source' && 'https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos' || '' }}
         import-token: ${{ secrets.REPO_TOKEN }}
         colcon-defaults: |
           {
             "build": {
               "mixin": [
-                  "coverage-gcc",
-                  "coverage-pytest"
-              ]
-            },
-            "test": {
-              "mixin": [
-                "coverage-pytest"
+                  "coverage-gcc"
               ]
             }
           }


### PR DESCRIPTION
Allows choosing either binary build or source build, and allows easily adding another OS (preparation for #109, #115).

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>