### PR TITLE
Add macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
             build-type: binary
           - os: ubuntu-latest
             build-type: source
+          - os: macos-latest
+            build-type: source
     steps:
     - uses: actions/checkout@v2
     - uses: ros-tooling/setup-ros@master


### PR DESCRIPTION
Closes #115

This adds macOS to the CI config matrix.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>