### PR TITLE
Remove unused variable to fix warning on macOS

### DIFF
--- a/email/src/email/response_utils.cpp
+++ b/email/src/email/response_utils.cpp
@@ -33,7 +33,6 @@ static constexpr auto HEADER_CC = "Cc";
 static constexpr auto HEADER_FROM = "From";
 static constexpr auto HEADER_IN_REPLY_TO = "In-Reply-To";
 static constexpr auto HEADER_MESSAGE_ID = "Message-ID";
-static constexpr auto HEADER_REFERENCES = "References";
 static constexpr auto HEADER_SUBJECT = "Subject";
 static constexpr auto HEADER_TO = "To";
 static const std::regex REGEX_BODY(R"((?:\r?\n){2}((?:.*\n*)*)(?:\r?\n)?)");


### PR DESCRIPTION
Relates to #115

Relates to #117

Fixes warning on macOS:

> /Users/chris/ros2_ws/src/rmw_email/email/src/email/response_utils.cpp:36:23: warning: unused variable 'HEADER_REFERENCES' [-Wunused-const-variable]
> static constexpr auto HEADER_REFERENCES = "References";

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>