### PR TITLE
Re-add codecov token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           }
     - uses: codecov/codecov-action@v1
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: ros_ws/lcov/total_coverage.info
         flags: unittests
         name: codecov-umbrella


### PR DESCRIPTION
It was removed in #106, but it seems like it's needed for private repos on GitHub.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>