### PR TITLE
Use logger in Options class

### DIFF
--- a/email/include/email/options.hpp
+++ b/email/include/email/options.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Christophe Bedard
+// Copyright 2020-2021 Christophe Bedard
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 #include <regex>
 #include <string>
 
+#include "email/log.hpp"
 #include "email/types.hpp"
 #include "email/visibility_control.hpp"
 
@@ -95,6 +96,10 @@ private:
   static
   std::optional<std::string>
   get_options_file_content();
+
+  static
+  std::shared_ptr<Logger>
+  logger();
 
   UserInfo::SharedPtrConst user_info_;
   EmailRecipients::SharedPtrConst recipients_;

--- a/email/src/context.cpp
+++ b/email/src/context.cpp
@@ -52,12 +52,14 @@ Context::init()
   if (is_valid()) {
     throw ContextAlreadyInitializedError();
   }
+  init_common();
   auto options = Options::parse_options_from_file();
   if (!options) {
     throw ContextInitFailedError("parsing options from file");
   }
   options_ = options.value();
-  init_common();
+
+  is_valid_ = true;
 }
 
 void
@@ -66,13 +68,15 @@ Context::init(int argc, char const * const argv[])
   if (is_valid()) {
     throw ContextAlreadyInitializedError();
   }
+  init_common();
   auto options = Options::parse_options_from_args(argc, argv);
   if (!options) {
     // Exit with non-zero instead of throwing an exception, since this is CLI args-related
     exit(1);
   }
   options_ = options.value();
-  init_common();
+
+  is_valid_ = true;
 }
 
 void
@@ -81,7 +85,6 @@ Context::init_common()
   log::init_from_env();
   spdlog::get("root")->debug("logging initialized");
   logger_ = log::create("Context");
-  is_valid_ = true;
 }
 
 bool


### PR DESCRIPTION
Instead of `std::cerr`.

I had to change the context initialization order to make sure logging is initialized before the options file is parsed.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>