### PR TITLE
Allow having identical loggers for pubs & subs

### DIFF
--- a/email/src/publisher.cpp
+++ b/email/src/publisher.cpp
@@ -27,14 +27,12 @@ namespace email
 
 Publisher::Publisher(const std::string & topic_name)
 : PubSubObject(topic_name),
-  logger_(log::create("Publisher::" + topic_name)),
+  logger_(log::get_or_create("Publisher::" + topic_name)),
   sender_(get_global_context()->get_sender())
 {}
 
 Publisher::~Publisher()
-{
-  log::remove(logger_);
-}
+{}
 
 void
 Publisher::publish(const std::string & message, std::optional<EmailHeaders> additional_headers)

--- a/email/src/subscriber.cpp
+++ b/email/src/subscriber.cpp
@@ -31,7 +31,7 @@ namespace email
 
 Subscriber::Subscriber(const std::string & topic_name)
 : PubSubObject(topic_name),
-  logger_(log::create("Subscriber::" + topic_name)),
+  logger_(log::get_or_create("Subscriber::" + topic_name)),
   messages_(std::make_shared<SafeQueue<std::string>>())
 {
   // Register with handler
@@ -41,9 +41,7 @@ Subscriber::Subscriber(const std::string & topic_name)
 }
 
 Subscriber::~Subscriber()
-{
-  log::remove(logger_);
-}
+{}
 
 bool
 Subscriber::has_message()


### PR DESCRIPTION
A `test_rmw_implementation` test was failing because two loggers were getting created with the same name: `Publisher::/test0`. The test was creating two publishers with the same topic name. I forgot that you can have two publishers/subscribers on the same topic.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>