### PR TITLE
Use random prefix/base value for GID

### DIFF
--- a/email/src/gid.cpp
+++ b/email/src/gid.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <atomic>
+#include <random>
 #include <string>
 
 #include "email/gid.hpp"
@@ -41,9 +42,13 @@ Gid::as_string() const
 GidValue
 Gid::new_value()
 {
-  // TODO(christophebedard) generate a random UUID?
+  // Generate random prefix
+  static std::random_device random_device;
+  static std::mt19937 gen(random_device());
+  static auto prefix = gen();
+  // Add sequence ID to prefix
   static std::atomic<GidValue> id;
-  return id++;
+  return prefix + id++;
 }
 
 }  // namespace email

--- a/rmw_email_cpp/src/gid.cpp
+++ b/rmw_email_cpp/src/gid.cpp
@@ -21,7 +21,7 @@ rmw_gid_t convert_gid(const email::Gid & gid)
   rmw_gid_t rmw_gid = {};
   rmw_gid.implementation_identifier = email_identifier;
 
-  email::GidValue new_id = gid.value();
+  const email::GidValue new_id = gid.value();
   static_assert(
     sizeof(decltype(new_id)) <= RMW_GID_STORAGE_SIZE,
     "RMW_GID_STORAGE_SIZE insufficient to store rmw_email_cpp GID");


### PR DESCRIPTION
This way the Nth publisher or subscription in process X won't have the same GID as the Nth publisher/subscription in process Y.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>