### PR TITLE
Check log initialization status and add test

### DIFF
--- a/email/CMakeLists.txt
+++ b/email/CMakeLists.txt
@@ -117,6 +117,10 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_log
+    test/test_log.cpp
+  )
+  target_link_libraries(test_log ${PROJECT_NAME})
   ament_add_gtest(test_utils
     test/test_utils.cpp
     ENV EMAIL_TEST_UTILS_TEST_ENV_VAR=value42 EMAIL_TEST_UTILS_FILE=${CMAKE_CURRENT_SOURCE_DIR}/test/test_utils.cpp

--- a/email/include/email/log.hpp
+++ b/email/include/email/log.hpp
@@ -16,6 +16,7 @@
 #define EMAIL__LOG_HPP_
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 
 #include "rcpputils/filesystem_helper.hpp"
@@ -34,6 +35,33 @@ using Logger = spdlog::logger;
 namespace log
 {
 
+/// Generic logging error.
+class LoggingError : public std::runtime_error
+{
+public:
+  explicit LoggingError(const std::string & msg)
+  : std::runtime_error(msg)
+  {}
+};
+
+/// Error when logging is not initialized.
+class LoggingNotInitializedError : public LoggingError
+{
+public:
+  LoggingNotInitializedError()
+  : LoggingError("logging not initialized")
+  {}
+};
+
+/// Error when logging is already initialized.
+class LoggingAlreadyInitializedError : public LoggingError
+{
+public:
+  LoggingAlreadyInitializedError()
+  : LoggingError("logging already initialized")
+  {}
+};
+
 /// Logging level.
 enum Level
 {
@@ -48,11 +76,15 @@ enum Level
 /// Initialize logging.
 /**
  * \param level the console logging level
+ * \throw `LoggingAlreadyInitializedError` if logging is already intialized
  */
 void
 init(const Level & level);
 
 /// Initialize logging using environment variable value for the logging level.
+/**
+ * \throw `LoggingAlreadyInitializedError` if logging is already intialized
+ */
 void
 init_from_env();
 
@@ -62,6 +94,7 @@ init_from_env();
  *
  * \param name the name of the logger
  * \return the logger
+ * \throw `LoggingNotInitializedError` if logging is not intialized
  */
 std::shared_ptr<Logger>
 create(const std::string & name);
@@ -72,6 +105,7 @@ create(const std::string & name);
  *
  * \param name the name of the logger
  * \return the logger
+ * \throw `LoggingNotInitializedError` if logging is not intialized
  */
 std::shared_ptr<Logger>
 get_or_create(const std::string & name);
@@ -79,6 +113,7 @@ get_or_create(const std::string & name);
 /// Remove an existing logger.
 /**
  * \param name the logger
+ * \throw `LoggingNotInitializedError` if logging is not intialized
  */
 void
 remove(const std::shared_ptr<Logger> & logger);

--- a/email/test/test_log.cpp
+++ b/email/test/test_log.cpp
@@ -1,0 +1,38 @@
+// Copyright 2021 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "email/log.hpp"
+
+TEST(TestLog, init) {
+  EXPECT_THROW(email::log::create("some logger"), email::log::LoggingNotInitializedError);
+  EXPECT_THROW(
+    email::log::get_or_create("some logger"), email::log::LoggingNotInitializedError);
+  EXPECT_THROW(
+    email::log::remove(std::shared_ptr<email::Logger>(nullptr)),
+    email::log::LoggingNotInitializedError);
+  EXPECT_NO_THROW(email::log::shutdown());
+
+  email::log::init(email::log::Level::debug);
+  EXPECT_THROW(
+    email::log::init(email::log::Level::debug), email::log::LoggingAlreadyInitializedError);
+  EXPECT_NO_THROW(email::log::create("some logger"));
+  EXPECT_NO_THROW(email::log::get_or_create("some logger"));
+  auto logger = email::log::get_or_create("some logger");
+  EXPECT_NO_THROW(email::log::remove(logger));
+  email::log::shutdown();
+}


### PR DESCRIPTION
This adds checks to make sure logging is initialized when trying to create/get loggers. It previously caused a few headaches because trying to create a logger when logging isn't initialized often leads to a segfault.

This also adds a test for that.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>