### PR TITLE
Allow logging to be initialized when needed

### DIFF
--- a/email/include/email/log.hpp
+++ b/email/include/email/log.hpp
@@ -53,15 +53,6 @@ public:
   {}
 };
 
-/// Error when logging is already initialized.
-class LoggingAlreadyInitializedError : public LoggingError
-{
-public:
-  LoggingAlreadyInitializedError()
-  : LoggingError("logging already initialized")
-  {}
-};
-
 /// Logging level.
 enum Level
 {
@@ -92,9 +83,10 @@ init_from_env();
 /**
  * Uses sink(s) and log level from the root logger.
  *
+ * Will initialize logging from environment if not initialized.
+ *
  * \param name the name of the logger
  * \return the logger
- * \throw `LoggingNotInitializedError` if logging is not intialized
  */
 std::shared_ptr<Logger>
 create(const std::string & name);
@@ -102,6 +94,8 @@ create(const std::string & name);
 /// Get an existing logger or create it from the root logger.
 /**
  * Useful for sharing a logger.
+ *
+ * Will initialize logging from environment if not initialized.
  *
  * \param name the name of the logger
  * \return the logger

--- a/email/src/log.cpp
+++ b/email/src/log.cpp
@@ -109,10 +109,13 @@ static bool is_logging_initialized = false;
 void
 init(const Level & level)
 {
-  std::scoped_lock<std::mutex> lock(logger_mutex);
+  // If logging is already initialized, just set console log level
   if (is_logging_initialized) {
-    throw LoggingAlreadyInitializedError();
+    sink_console->set_level(level_to_spdlog(level));
+    return;
   }
+
+  std::scoped_lock<std::mutex> lock(logger_mutex);
   if (nullptr != root_logger) {
     return;
   }
@@ -159,10 +162,10 @@ init_from_env()
 std::shared_ptr<spdlog::logger>
 create(const std::string & name)
 {
-  std::scoped_lock<std::mutex> lock(logger_mutex);
   if (!is_logging_initialized) {
-    throw LoggingNotInitializedError();
+    init_from_env();
   }
+  std::scoped_lock<std::mutex> lock(logger_mutex);
   const auto & sinks = root_logger->sinks();
   auto logger = std::make_shared<spdlog::logger>(name, sinks.cbegin(), sinks.cend());
   logger->set_level(root_logger->level());
@@ -174,7 +177,7 @@ std::shared_ptr<Logger>
 get_or_create(const std::string & name)
 {
   if (!is_logging_initialized) {
-    throw LoggingNotInitializedError();
+    init_from_env();
   }
   std::shared_ptr<spdlog::logger> logger = spdlog::get(name);
   if (nullptr == logger) {
@@ -186,6 +189,7 @@ get_or_create(const std::string & name)
 void
 remove(const std::shared_ptr<Logger> & logger)
 {
+  // Doesn't make sense to remove a logger if logging isn't initialized
   if (!is_logging_initialized) {
     throw LoggingNotInitializedError();
   }

--- a/email/test/test_log.cpp
+++ b/email/test/test_log.cpp
@@ -28,8 +28,7 @@ TEST(TestLog, init) {
   EXPECT_NO_THROW(email::log::shutdown());
 
   email::log::init(email::log::Level::debug);
-  EXPECT_THROW(
-    email::log::init(email::log::Level::debug), email::log::LoggingAlreadyInitializedError);
+  EXPECT_NO_THROW(email::log::init(email::log::Level::warn));
   EXPECT_NO_THROW(email::log::create("some logger"));
   EXPECT_NO_THROW(email::log::get_or_create("some logger"));
   auto logger = email::log::get_or_create("some logger");


### PR DESCRIPTION
This is needed because the rmw implementation creates objects that create loggers before the rmw implementation initializes logging. Let's just allow logging to be initialized from the environment when needed.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>