### PR TITLE
Convert GID to string once on construction, add GID-specific test

### DIFF
--- a/email/CMakeLists.txt
+++ b/email/CMakeLists.txt
@@ -118,6 +118,10 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_gid
+    test/test_gid.cpp
+  )
+  target_link_libraries(test_gid ${PROJECT_NAME})
   ament_add_gtest(test_log
     test/test_log.cpp
   )

--- a/email/include/email/gid.hpp
+++ b/email/include/email/gid.hpp
@@ -55,8 +55,7 @@ public:
   /**
    * \return the GID as a string
    */
-  EMAIL_PUBLIC
-  std::string
+  const std::string &
   as_string() const;
 
 private:
@@ -67,7 +66,16 @@ private:
   GidValue
   new_value();
 
+  /// Convert a GID value to a string.
+  /**
+   * \return the GID value as a string
+   */
+  static
+  std::string
+  to_string(const GidValue value);
+
   const GidValue value_;
+  const std::string value_string_;
 };
 
 }  // namespace email

--- a/email/src/gid.cpp
+++ b/email/src/gid.cpp
@@ -22,7 +22,8 @@ namespace email
 {
 
 Gid::Gid()
-: value_(Gid::new_value())
+: value_(Gid::new_value()),
+  value_string_(Gid::to_string(value_))
 {}
 
 Gid::~Gid() {}
@@ -33,10 +34,10 @@ Gid::value() const
   return value_;
 }
 
-std::string
+const std::string &
 Gid::as_string() const
 {
-  return std::to_string(value_);
+  return value_string_;
 }
 
 GidValue
@@ -49,6 +50,12 @@ Gid::new_value()
   // Add sequence ID to prefix
   static std::atomic<GidValue> id;
   return prefix + id++;
+}
+
+std::string
+Gid::to_string(const GidValue value)
+{
+  return std::to_string(value);
 }
 
 }  // namespace email

--- a/email/test/test_gid.cpp
+++ b/email/test/test_gid.cpp
@@ -1,0 +1,41 @@
+// Copyright 2021 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "email/gid.hpp"
+
+TEST(TestGid, gid) {
+  email::Gid gid1;
+  email::Gid gid2;
+  email::Gid gid3;
+
+  // May be overkill
+  EXPECT_NE(0u, gid1.value());
+  EXPECT_NE(0u, gid2.value());
+  EXPECT_NE(0u, gid3.value());
+  EXPECT_NE(gid1.value(), gid2.value());
+  EXPECT_NE(gid1.value(), gid3.value());
+  EXPECT_NE(gid2.value(), gid3.value());
+  EXPECT_FALSE(gid1.as_string().empty());
+  EXPECT_FALSE(gid2.as_string().empty());
+  EXPECT_FALSE(gid3.as_string().empty());
+  EXPECT_STRNE(gid1.as_string().c_str(), gid2.as_string().c_str());
+  EXPECT_STRNE(gid1.as_string().c_str(), gid3.as_string().c_str());
+  EXPECT_STRNE(gid2.as_string().c_str(), gid3.as_string().c_str());
+
+  // Check sequentiality (wow that's a real word)
+  EXPECT_EQ(1u, gid2.value() - gid1.value());
+  EXPECT_EQ(1u, gid3.value() - gid2.value());
+}

--- a/email/test/test_pub_sub.cpp
+++ b/email/test/test_pub_sub.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Christophe Bedard
+// Copyright 2020-2021 Christophe Bedard
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ TEST(TestPubSub, validate_topic_name) {
 }
 
 TEST(TestPubSub, gid) {
+  // Just check that they don't have the same GID
   PubSubObjectStub o1("/my_topic");
   PubSubObjectStub o2("/my_other_topic");
   EXPECT_NE(o1.get_gid().value(), o2.get_gid().value());


### PR DESCRIPTION
Will be useful for #159, and there's no reason to construct a string on demand every time.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>