### PR TITLE
Add message info

### DIFF
--- a/email/CMakeLists.txt
+++ b/email/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SOURCES
   src/guard_condition.cpp
   src/init.cpp
   src/log.cpp
+  src/message_info.cpp
   src/options.cpp
   src/pub_sub.cpp
   src/publisher.cpp
@@ -55,6 +56,7 @@ set(SOURCES
   src/service_server.cpp
   src/subscriber.cpp
   src/subscription_handler.cpp
+  src/timestamp.cpp
   src/utils.cpp
   src/wait.cpp
   src/wait_set.cpp
@@ -147,6 +149,10 @@ if(BUILD_TESTING)
     test/test_service.cpp
   )
   target_link_libraries(test_service ${PROJECT_NAME})
+  ament_add_gtest(test_timestamp
+    test/test_timestamp.cpp
+  )
+  target_link_libraries(test_timestamp ${PROJECT_NAME})
   ament_add_gtest(test_wait_set
     test/test_wait_set.cpp
   )

--- a/email/include/email/gid.hpp
+++ b/email/include/email/gid.hpp
@@ -33,12 +33,23 @@ typedef uint32_t GidValue;
 class Gid
 {
 public:
+  /// Get a new GID.
+  EMAIL_PUBLIC
+  static
+  Gid
+  new_gid();
+
   /// Constructor.
   /**
-   * A new GID is automatically created.
+   * To create a new GID, see Gid::new().
+   *
+   * \param value the value for this GID
    */
   EMAIL_PUBLIC
-  Gid();
+  explicit Gid(const GidValue value);
+
+  EMAIL_PUBLIC
+  Gid(const Gid &) = default;
 
   EMAIL_PUBLIC
   virtual ~Gid();
@@ -53,23 +64,28 @@ public:
 
   /// Get the GID as a string.
   /**
-   * \return the GID as a string
+   * This string can be converted back to a GID using from_string().
    */
+  EMAIL_PUBLIC
   const std::string &
-  as_string() const;
+  to_string() const;
+
+  /// Get a GID object from a string.
+  /**
+   * The string should have been generated using to_string().
+   */
+  EMAIL_PUBLIC
+  static
+  Gid
+  from_string(const std::string & str);
 
 private:
-  EMAIL_DISABLE_COPY(Gid)
-
   /// Get a new value.
   static
   GidValue
   new_value();
 
   /// Convert a GID value to a string.
-  /**
-   * \return the GID value as a string
-   */
   static
   std::string
   to_string(const GidValue value);

--- a/email/include/email/message_info.hpp
+++ b/email/include/email/message_info.hpp
@@ -1,0 +1,84 @@
+// Copyright 2021 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EMAIL__MESSAGE_INFO_HPP_
+#define EMAIL__MESSAGE_INFO_HPP_
+
+#include "email/gid.hpp"
+#include "email/macros.hpp"
+#include "email/timestamp.hpp"
+#include "email/types.hpp"
+#include "email/visibility_control.hpp"
+
+namespace email
+{
+
+/// Message info container.
+/**
+ * Contains metadata about a received message.
+ */
+class MessageInfo
+{
+public:
+  /// Constructor.
+  EMAIL_PUBLIC
+  MessageInfo(
+    const Timestamp & source_timestamp,
+    const Timestamp & received_timestamp,
+    const Gid & publisher_gid);
+
+  EMAIL_PUBLIC
+  MessageInfo(const MessageInfo &) = default;
+
+  EMAIL_PUBLIC
+  ~MessageInfo();
+
+  /// Get the message source timestamp.
+  EMAIL_PUBLIC
+  const Timestamp &
+  source_timestamp() const;
+
+  /// Get the message reception timestamp.
+  EMAIL_PUBLIC
+  const Timestamp &
+  received_timestamp() const;
+
+  /// Get the publisher GID.
+  EMAIL_PUBLIC
+  const Gid &
+  publisher_gid() const;
+
+  /// Get a MessageInfo object from email headers.
+  /**
+   * The received timestamp will be created using Timestamp::now().
+   */
+  static
+  MessageInfo
+  from_headers(const EmailHeaders & headers);
+
+  /// Custom header name for publisher GID.
+  static constexpr auto HEADER_PUBLISHER_GID = "Publisher-GID";
+
+  /// Custom header name for source timestamp.
+  static constexpr auto HEADER_SOURCE_TIMESTAMP = "Source-Timestamp";
+
+private:
+  const Timestamp source_timestamp_;
+  const Timestamp received_timestamp_;
+  const Gid publisher_gid_;
+};
+
+}  // namespace email
+
+#endif  // EMAIL__MESSAGE_INFO_HPP_

--- a/email/include/email/subscriber.hpp
+++ b/email/include/email/subscriber.hpp
@@ -19,11 +19,14 @@
 #include <memory>
 #include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
 #include <string>
+#include <utility>
 
 #include "email/log.hpp"
 #include "email/macros.hpp"
+#include "email/message_info.hpp"
 #include "email/pub_sub.hpp"
 #include "email/safe_queue.hpp"
+#include "email/subscription_handler.hpp"
 #include "email/types.hpp"
 #include "email/visibility_control.hpp"
 
@@ -66,11 +69,21 @@ public:
   std::optional<std::string>
   get_message();
 
+  /// Get a message with info if there is one.
+  /**
+   * This is the same as "taking" a message with its info if there is one.
+   *
+   * \return the message & message info pair, or `std::nullopt` if there is none
+   */
+  EMAIL_PUBLIC
+  std::optional<std::pair<std::string, MessageInfo>>
+  get_message_with_info();
+
 private:
   EMAIL_DISABLE_COPY(Subscriber)
 
   std::shared_ptr<Logger> logger_;
-  SafeQueue<std::string>::SharedPtr messages_;
+  SubscriptionHandler::SubscriberQueue::SharedPtr messages_;
 };
 
 }  // namespace email

--- a/email/include/email/timestamp.hpp
+++ b/email/include/email/timestamp.hpp
@@ -1,0 +1,93 @@
+// Copyright 2021 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EMAIL__TIMESTAMP_HPP_
+#define EMAIL__TIMESTAMP_HPP_
+
+#include <string>
+
+#include "spdlog/fmt/ostr.h"
+
+#include "email/macros.hpp"
+#include "email/visibility_control.hpp"
+
+namespace email
+{
+
+/// Timestamp with nanoseconds.
+/**
+ * Unix timestamp in nanoseconds.
+ */
+class Timestamp
+{
+public:
+  /// Get a new timestamp pointing to now from the Unix epoch.
+  EMAIL_PUBLIC
+  static
+  Timestamp
+  now();
+
+  /// Constructor.
+  /**
+   * \param nanoseconds the number of nanoseconds
+   */
+  EMAIL_PUBLIC
+  explicit Timestamp(const int64_t nanoseconds);
+
+  EMAIL_PUBLIC
+  Timestamp(const Timestamp &) = default;
+
+  EMAIL_PUBLIC
+  ~Timestamp();
+
+  /// Get the number of nanoseconds.
+  EMAIL_PUBLIC
+  int64_t
+  nanoseconds() const;
+
+  /// Convert the timestamp to a string.
+  /**
+   * This string can be converted back to a timestamp using from_string().
+   */
+  EMAIL_PUBLIC
+  std::string
+  to_string() const;
+
+  /// Get a timestamp object from a string.
+  /**
+   * The string should have been generated using to_string().
+   */
+  EMAIL_PUBLIC
+  static
+  Timestamp
+  from_string(const std::string & timestamp);
+
+private:
+  int64_t nanoseconds_;
+};
+
+}  // namespace email
+
+/// Formatting for Timestamp objects.
+template<>
+struct fmt::formatter<email::Timestamp>: formatter<string_view>
+{
+  template<typename FormatContext>
+  auto format(const email::Timestamp & ts, FormatContext & ctx)
+  {
+    return formatter<string_view>::format(ts.to_string(), ctx);
+  }
+};
+
+#endif  // EMAIL__TIMESTAMP_HPP_

--- a/email/include/email/utils.hpp
+++ b/email/include/email/utils.hpp
@@ -142,6 +142,15 @@ EMAIL_PUBLIC
 std::optional<int>
 optional_stoi(const std::string & str);
 
+/// Try to call `std::stoll`.
+/**
+ * \param std the string to convert to long int/long
+ * \return the number, or `std::nullopt` if it fails
+ */
+EMAIL_PUBLIC
+std::optional<int64_t>
+optional_stoll(const std::string & str);
+
 }  // namespace utils
 }  // namespace email
 

--- a/email/include/email/wait.hpp
+++ b/email/include/email/wait.hpp
@@ -18,12 +18,39 @@
 #include <chrono>
 #include <memory>
 #include <string>
+#include <utility>
 
+#include "email/message_info.hpp"
 #include "email/subscriber.hpp"
 #include "email/visibility_control.hpp"
 
 namespace email
 {
+
+/// Get a message with info from a subscription, waiting until one is available.
+/**
+ * For the meaning of the timeout parameter, see `WaitSet::wait`.
+ *
+ * \param subscription the subscription
+ * \param timeout the timeout
+ * \return the message & message info pair
+ * \see WaitSet::wait()
+ */
+EMAIL_PUBLIC
+std::pair<std::string, MessageInfo>
+wait_for_message_with_info(
+  Subscriber * subscription,
+  const std::chrono::milliseconds timeout = std::chrono::milliseconds(-1));
+
+/// Get a message with info from a subscription, waiting until one is available.
+/**
+ * \see wait_for_message(std::shared_ptr<Subscriber>, const std::chrono::milliseconds)
+ */
+EMAIL_PUBLIC
+std::pair<std::string, MessageInfo>
+wait_for_message_with_info(
+  std::shared_ptr<Subscriber> subscription,
+  const std::chrono::milliseconds timeout = std::chrono::milliseconds(-1));
 
 /// Get a message from a subscription, waiting until one is available.
 /**

--- a/email/src/gid.cpp
+++ b/email/src/gid.cpp
@@ -13,16 +13,24 @@
 // limitations under the License.
 
 #include <atomic>
+#include <cassert>
 #include <random>
 #include <string>
 
 #include "email/gid.hpp"
+#include "email/utils.hpp"
 
 namespace email
 {
 
-Gid::Gid()
-: value_(Gid::new_value()),
+Gid
+Gid::new_gid()
+{
+  return Gid(Gid::new_value());
+}
+
+Gid::Gid(const GidValue value)
+: value_(value),
   value_string_(Gid::to_string(value_))
 {}
 
@@ -35,9 +43,17 @@ Gid::value() const
 }
 
 const std::string &
-Gid::as_string() const
+Gid::to_string() const
 {
   return value_string_;
+}
+
+Gid
+Gid::from_string(const std::string & str)
+{
+  auto value_opt = utils::optional_stoul(str);
+  assert(value_opt.has_value());
+  return Gid(value_opt.value());
 }
 
 GidValue

--- a/email/src/message_info.cpp
+++ b/email/src/message_info.cpp
@@ -1,0 +1,71 @@
+// Copyright 2021 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+
+#include "email/email/response_utils.hpp"
+#include "email/gid.hpp"
+#include "email/message_info.hpp"
+#include "email/timestamp.hpp"
+
+namespace email
+{
+
+MessageInfo::MessageInfo(
+  const Timestamp & source_timestamp,
+  const Timestamp & received_timestamp,
+  const Gid & publisher_gid)
+: source_timestamp_(source_timestamp),
+  received_timestamp_(received_timestamp),
+  publisher_gid_(publisher_gid)
+{}
+
+MessageInfo::~MessageInfo() {}
+
+const Timestamp &
+MessageInfo::source_timestamp() const
+{
+  return source_timestamp_;
+}
+
+const Timestamp &
+MessageInfo::received_timestamp() const
+{
+  return received_timestamp_;
+}
+
+const Gid &
+MessageInfo::publisher_gid() const
+{
+  return publisher_gid_;
+}
+
+MessageInfo
+MessageInfo::from_headers(const EmailHeaders & headers)
+{
+  auto source_ts_opt = utils::response::get_header_value(
+    MessageInfo::HEADER_SOURCE_TIMESTAMP, headers);
+  auto publisher_gid_opt = utils::response::get_header_value(
+    MessageInfo::HEADER_PUBLISHER_GID, headers);
+  // TODO(christophebedard) handle missing header
+  assert(source_ts_opt.has_value());
+  assert(publisher_gid_opt.has_value());
+  const Timestamp source_timestamp = Timestamp::from_string(source_ts_opt.value());
+  const Timestamp received_timestamp = Timestamp::now();
+  const Gid publisher_gid = Gid::from_string(publisher_gid_opt.value());
+  MessageInfo info(source_timestamp, received_timestamp, publisher_gid);
+  return info;
+}
+
+}  // namespace email

--- a/email/src/pub_sub.cpp
+++ b/email/src/pub_sub.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Christophe Bedard
+// Copyright 2020-2021 Christophe Bedard
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #include <regex>
 #include <string>
 
+#include "email/gid.hpp"
 #include "email/pub_sub.hpp"
 
 namespace email
@@ -22,7 +23,7 @@ namespace email
 
 PubSubObject::PubSubObject(const std::string & topic_name)
 : topic_name_(topic_name),
-  gid_()
+  gid_(Gid::new_gid())
 {
   validate_topic_name(topic_name);
 }

--- a/email/src/publisher.cpp
+++ b/email/src/publisher.cpp
@@ -18,8 +18,10 @@
 #include "email/context.hpp"
 #include "email/email/sender.hpp"
 #include "email/log.hpp"
+#include "email/message_info.hpp"
 #include "email/pub_sub.hpp"
 #include "email/publisher.hpp"
+#include "email/timestamp.hpp"
 #include "email/types.hpp"
 
 namespace email
@@ -37,8 +39,17 @@ Publisher::~Publisher()
 void
 Publisher::publish(const std::string & message, std::optional<EmailHeaders> additional_headers)
 {
+  // Add GID and source timestamp to headers
+  EmailHeaders headers;
+  if (additional_headers.has_value()) {
+    headers = additional_headers.value();
+  }
+  // TODO(christophebedard) extract header key to constant
+  headers.insert({MessageInfo::HEADER_PUBLISHER_GID, get_gid().to_string()});
+  headers.insert({MessageInfo::HEADER_SOURCE_TIMESTAMP, Timestamp::now().to_string()});
+
   struct EmailContent content {get_topic_name(), message};
-  if (!sender_->send(content, additional_headers)) {
+  if (!sender_->send(content, headers)) {
     logger_->error("publish() failed");
   }
 }

--- a/email/src/subscriber.cpp
+++ b/email/src/subscriber.cpp
@@ -20,6 +20,7 @@
 
 #include "email/context.hpp"
 #include "email/log.hpp"
+#include "email/message_info.hpp"
 #include "email/pub_sub.hpp"
 #include "email/safe_queue.hpp"
 #include "email/subscriber.hpp"
@@ -32,7 +33,7 @@ namespace email
 Subscriber::Subscriber(const std::string & topic_name)
 : PubSubObject(topic_name),
   logger_(log::get_or_create("Subscriber::" + topic_name)),
-  messages_(std::make_shared<SafeQueue<std::string>>())
+  messages_(std::make_shared<SubscriptionHandler::SubscriberQueue>())
 {
   // Register with handler
   get_global_context()->get_subscription_handler()->register_subscriber(
@@ -51,6 +52,15 @@ Subscriber::has_message() const
 
 std::optional<std::string>
 Subscriber::get_message()
+{
+  if (!has_message()) {
+    return std::nullopt;
+  }
+  return messages_->dequeue().first;
+}
+
+std::optional<std::pair<std::string, MessageInfo>>
+Subscriber::get_message_with_info()
 {
   if (!has_message()) {
     return std::nullopt;

--- a/email/src/timestamp.cpp
+++ b/email/src/timestamp.cpp
@@ -1,0 +1,59 @@
+// Copyright 2021 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+#include <chrono>
+#include <string>
+
+#include "email/timestamp.hpp"
+#include "email/utils.hpp"
+
+namespace email
+{
+
+Timestamp
+Timestamp::now()
+{
+  auto now = std::chrono::system_clock::now().time_since_epoch();
+  auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(now);
+  return Timestamp(nanoseconds.count());
+}
+
+Timestamp::Timestamp(const int64_t nanoseconds)
+: nanoseconds_(nanoseconds)
+{}
+
+Timestamp::~Timestamp() {}
+
+int64_t
+Timestamp::nanoseconds() const
+{
+  return nanoseconds_;
+}
+
+std::string
+Timestamp::to_string() const
+{
+  return std::to_string(nanoseconds_);
+}
+
+Timestamp
+Timestamp::from_string(const std::string & timestamp)
+{
+  auto nanoseconds_opt = utils::optional_stoll(timestamp);
+  assert(nanoseconds_opt.has_value());
+  return Timestamp(nanoseconds_opt.value());
+}
+
+}  // namespace email

--- a/email/src/utils.cpp
+++ b/email/src/utils.cpp
@@ -116,5 +116,18 @@ optional_stoi(const std::string & str)
   return std::nullopt;
 }
 
+std::optional<int64_t>
+optional_stoll(const std::string & str)
+{
+  try {
+    return static_cast<int64_t>(std::stoll(str));
+  } catch (const std::invalid_argument &) {
+  } catch (const std::out_of_range &) {  // LCOV_EXCL_LINE
+  } catch (const std::exception &) {  // LCOV_EXCL_LINE
+  } catch (...) {  // LCOV_EXCL_LINE
+  }
+  return std::nullopt;
+}
+
 }  // namespace utils
 }  // namespace email

--- a/email/src/wait.cpp
+++ b/email/src/wait.cpp
@@ -12,18 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cassert>
 #include <chrono>
 #include <memory>
 #include <string>
+#include <utility>
 
+#include "email/message_info.hpp"
 #include "email/subscriber.hpp"
 #include "email/wait_set.hpp"
 
 namespace email
 {
 
-std::string
-wait_for_message(
+std::pair<std::string, MessageInfo>
+wait_for_message_with_info(
   Subscriber * subscription,
   const std::chrono::milliseconds timeout)
 {
@@ -31,7 +34,23 @@ wait_for_message(
   const bool timedout = waitset.wait(timeout);
   assert(!timedout);
 
-  return subscription->get_message().value();
+  return subscription->get_message_with_info().value();
+}
+
+std::pair<std::string, MessageInfo>
+wait_for_message_with_info(
+  std::shared_ptr<Subscriber> subscription,
+  const std::chrono::milliseconds timeout)
+{
+  return wait_for_message_with_info(subscription.get(), timeout);
+}
+
+std::string
+wait_for_message(
+  Subscriber * subscription,
+  const std::chrono::milliseconds timeout)
+{
+  return wait_for_message_with_info(subscription, timeout).first;
 }
 
 std::string

--- a/email/test/test_gid.cpp
+++ b/email/test/test_gid.cpp
@@ -14,12 +14,14 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+
 #include "email/gid.hpp"
 
 TEST(TestGid, gid) {
-  email::Gid gid1;
-  email::Gid gid2;
-  email::Gid gid3;
+  email::Gid gid1 = email::Gid::new_gid();
+  email::Gid gid2 = email::Gid::new_gid();
+  email::Gid gid3 = email::Gid::new_gid();
 
   // May be overkill
   EXPECT_NE(0u, gid1.value());
@@ -28,14 +30,22 @@ TEST(TestGid, gid) {
   EXPECT_NE(gid1.value(), gid2.value());
   EXPECT_NE(gid1.value(), gid3.value());
   EXPECT_NE(gid2.value(), gid3.value());
-  EXPECT_FALSE(gid1.as_string().empty());
-  EXPECT_FALSE(gid2.as_string().empty());
-  EXPECT_FALSE(gid3.as_string().empty());
-  EXPECT_STRNE(gid1.as_string().c_str(), gid2.as_string().c_str());
-  EXPECT_STRNE(gid1.as_string().c_str(), gid3.as_string().c_str());
-  EXPECT_STRNE(gid2.as_string().c_str(), gid3.as_string().c_str());
+  EXPECT_FALSE(gid1.to_string().empty());
+  EXPECT_FALSE(gid2.to_string().empty());
+  EXPECT_FALSE(gid3.to_string().empty());
+  EXPECT_STRNE(gid1.to_string().c_str(), gid2.to_string().c_str());
+  EXPECT_STRNE(gid1.to_string().c_str(), gid3.to_string().c_str());
+  EXPECT_STRNE(gid2.to_string().c_str(), gid3.to_string().c_str());
 
   // Check sequentiality (wow that's a real word)
   EXPECT_EQ(1u, gid2.value() - gid1.value());
   EXPECT_EQ(1u, gid3.value() - gid2.value());
+}
+
+TEST(TestGid, string) {
+  email::Gid gid = email::Gid::new_gid();
+  auto str = gid.to_string();
+  email::Gid gid_str = email::Gid::from_string(str);
+
+  EXPECT_EQ(gid.value(), gid_str.value());
 }

--- a/email/test/test_pub_sub.cpp
+++ b/email/test/test_pub_sub.cpp
@@ -44,5 +44,5 @@ TEST(TestPubSub, gid) {
   PubSubObjectStub o1("/my_topic");
   PubSubObjectStub o2("/my_other_topic");
   EXPECT_NE(o1.get_gid().value(), o2.get_gid().value());
-  EXPECT_STRNE(o1.get_gid().as_string().c_str(), o2.get_gid().as_string().c_str());
+  EXPECT_STRNE(o1.get_gid().to_string().c_str(), o2.get_gid().to_string().c_str());
 }

--- a/email/test/test_timestamp.cpp
+++ b/email/test/test_timestamp.cpp
@@ -1,0 +1,41 @@
+// Copyright 2021 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "email/timestamp.hpp"
+
+TEST(TestTimestamp, init) {
+  email::Timestamp ts1 = email::Timestamp::now();
+  EXPECT_NE(0u, ts1.nanoseconds());
+
+  email::Timestamp ts2 = email::Timestamp::now();
+  EXPECT_NE(0u, ts2.nanoseconds());
+
+  EXPECT_LT(ts1.nanoseconds(), ts2.nanoseconds());
+}
+
+TEST(TestTimestamp, string) {
+  email::Timestamp ts = email::Timestamp::now();
+  auto str = ts.to_string();
+  email::Timestamp ts_str = email::Timestamp::from_string(str);
+
+  EXPECT_EQ(ts.nanoseconds(), ts_str.nanoseconds());
+}
+
+TEST(TestTimestamp, format) {
+  printf("%s\n", fmt::format("timestamp: {}", email::Timestamp::now()).c_str());
+}

--- a/email/test/test_utils.cpp
+++ b/email/test/test_utils.cpp
@@ -125,4 +125,7 @@ TEST(TestUtils, optional_stox) {
   auto stoul_opt = email::utils::optional_stoul("42");
   ASSERT_TRUE(stoul_opt.has_value());
   EXPECT_EQ(42ul, stoul_opt);
+  auto stoll_opt = email::utils::optional_stoll("42");
+  ASSERT_TRUE(stoll_opt.has_value());
+  EXPECT_EQ(42l, stoll_opt);
 }

--- a/rmw_email_cpp/CMakeLists.txt
+++ b/rmw_email_cpp/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(${PROJECT_NAME}
   src/gid.cpp
   src/guard_condition.cpp
   src/identifier.cpp
+  src/timestamp.cpp
 
   src/rmw_client.cpp
   src/rmw_event.cpp

--- a/rmw_email_cpp/include/rmw_email_cpp/timestamp.hpp
+++ b/rmw_email_cpp/include/rmw_email_cpp/timestamp.hpp
@@ -1,0 +1,24 @@
+// Copyright 2021 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_EMAIL_CPP__TIMESTAMP_HPP_
+#define RMW_EMAIL_CPP__TIMESTAMP_HPP_
+
+#include "email/timestamp.hpp"
+#include "rmw/types.h"
+
+/// Convert timestamp from email to rmw.
+rmw_time_point_value_t convert_timestamp(const email::Timestamp & timestamp);
+
+#endif  // RMW_EMAIL_CPP__TIMESTAMP_HPP_

--- a/rmw_email_cpp/src/timestamp.cpp
+++ b/rmw_email_cpp/src/timestamp.cpp
@@ -1,0 +1,21 @@
+// Copyright 2021 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "email/timestamp.hpp"
+#include "rmw/types.h"
+
+rmw_time_point_value_t convert_timestamp(const email::Timestamp & timestamp)
+{
+  return timestamp.nanoseconds();
+}


### PR DESCRIPTION
Closes #159

Closes #160

This adds a `MessageInfo` class that contains a source and a received `Timestamp` and a publisher `Gid`. `Timestamp` and `Gid` can be converted to string and back from string.

The source timestamp & publisher GID are sent as additional headers (as strings). They are converted back into objects upon reception and reception timestamp is created. Then all of that is put into a `MessageInfo` object and made available through a new `Subscriber::get_message_with_info()` method and new `wait_for_message_with_info()` functions.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>