### PR TITLE
Add GidObject

### DIFF
--- a/email/include/email/gid.hpp
+++ b/email/include/email/gid.hpp
@@ -94,6 +94,35 @@ private:
   const std::string value_string_;
 };
 
+/// Abstract object with a GID.
+/**
+ * TODO(christophebedard) move to its own header
+ */
+class GidObject
+{
+public:
+  /// Get the unique ID (GID) for this object.
+  /**
+   * \return the GID
+   */
+  EMAIL_PUBLIC
+  const Gid &
+  get_gid() const;
+
+protected:
+  /// Constructor
+  EMAIL_PUBLIC
+  GidObject();
+
+  EMAIL_PUBLIC
+  virtual ~GidObject();
+
+private:
+  EMAIL_DISABLE_COPY(GidObject)
+
+  const Gid gid_;
+};
+
 }  // namespace email
 
 #endif  // EMAIL__GID_HPP_

--- a/email/include/email/pub_sub.hpp
+++ b/email/include/email/pub_sub.hpp
@@ -39,7 +39,7 @@ public:
 /**
  * Abstract class representing common publishing and subscribing elements.
  */
-class PubSubObject
+class PubSubObject : public GidObject
 {
 public:
   /// Get the topic name.
@@ -49,14 +49,6 @@ public:
   EMAIL_PUBLIC
   std::string
   get_topic_name() const;
-
-  /// Get the unique ID (GID) for this object.
-  /**
-   * \return the GID
-   */
-  EMAIL_PUBLIC
-  const Gid &
-  get_gid() const;
 
 protected:
   /// Constructor.
@@ -84,7 +76,6 @@ private:
   static const std::regex REGEX_NEWLINE;
 
   const std::string topic_name_;
-  const Gid gid_;
 };
 
 }  // namespace email

--- a/email/include/email/service.hpp
+++ b/email/include/email/service.hpp
@@ -19,6 +19,7 @@
 #include <stdexcept>
 #include <string>
 
+#include "email/gid.hpp"
 #include "email/macros.hpp"
 #include "email/visibility_control.hpp"
 
@@ -38,7 +39,7 @@ public:
 /**
  * Abstract class representing common service elements.
  */
-class ServiceObject
+class ServiceObject : public GidObject
 {
 public:
   /// Get the service name.

--- a/email/src/gid.cpp
+++ b/email/src/gid.cpp
@@ -74,4 +74,16 @@ Gid::to_string(const GidValue value)
   return std::to_string(value);
 }
 
+GidObject::GidObject()
+: gid_(Gid::new_gid())
+{}
+
+GidObject::~GidObject() {}
+
+const Gid &
+GidObject::get_gid() const
+{
+  return gid_;
+}
+
 }  // namespace email

--- a/email/src/pub_sub.cpp
+++ b/email/src/pub_sub.cpp
@@ -22,8 +22,8 @@ namespace email
 {
 
 PubSubObject::PubSubObject(const std::string & topic_name)
-: topic_name_(topic_name),
-  gid_(Gid::new_gid())
+: GidObject(),
+  topic_name_(topic_name)
 {
   validate_topic_name(topic_name);
 }
@@ -34,12 +34,6 @@ std::string
 PubSubObject::get_topic_name() const
 {
   return topic_name_;
-}
-
-const Gid &
-PubSubObject::get_gid() const
-{
-  return gid_;
 }
 
 void

--- a/email/src/service.cpp
+++ b/email/src/service.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Christophe Bedard
+// Copyright 2020-2021 Christophe Bedard
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,13 +15,15 @@
 #include <regex>
 #include <string>
 
+#include "email/gid.hpp"
 #include "email/service.hpp"
 
 namespace email
 {
 
 ServiceObject::ServiceObject(const std::string & service_name)
-: service_name_(service_name)
+: GidObject(),
+  service_name_(service_name)
 {
   validate_service_name(service_name);
 }

--- a/email/test/test_gid.cpp
+++ b/email/test/test_gid.cpp
@@ -51,3 +51,16 @@ TEST(TestGid, string) {
 
   EXPECT_DEATH(email::Gid::from_string("abc"), "");
 }
+
+class GidObjectStub : public email::GidObject
+{
+public:
+  GidObjectStub()
+  : GidObject()
+  {}
+};
+
+TEST(TestGidObject, init) {
+  auto gid_object = GidObjectStub();
+  EXPECT_NE(0u, gid_object.get_gid().value());
+}


### PR DESCRIPTION
Follow-up to #170

This adds an abstract `GidObject` class with a GID so that `PubSubObject` and `ServiceObjec` can inherit from it.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>