### PR TITLE
Increase tolerance in test_wait_set

### DIFF
--- a/email/test/test_wait_set.cpp
+++ b/email/test/test_wait_set.cpp
@@ -89,7 +89,7 @@ TEST_F(TestWaitSet, guard_condition) {
     // Check delay to make sure it's close to the expected delay
     auto actual_delay = end - start;
     auto diff = std::chrono::abs(actual_delay - delay);
-    EXPECT_TRUE(diff < std::chrono::milliseconds(10)) <<
+    EXPECT_TRUE(diff < std::chrono::milliseconds(15)) <<
       "diff=" << std::chrono::duration_cast<std::chrono::milliseconds>(diff).count() << " ms";
     trigger_thread.join();
     ASSERT_EQ(1u, waitset.get_guard_conditions().size());


### PR DESCRIPTION
It failed in the binary job of the last PR at diff = 12 ms.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>