### PR TITLE
Fix rmw warnings and errors

### DIFF
--- a/rmw_email_cpp/src/rmw_serialize.cpp
+++ b/rmw_email_cpp/src/rmw_serialize.cpp
@@ -26,7 +26,7 @@ extern "C" rmw_ret_t rmw_get_serialized_message_size(
   static_cast<void>(type_support);
   static_cast<void>(message_bounds);
   static_cast<void>(size);
-  RMW_SET_ERROR_MSG("rmw_get_serialized_message_size: unimplemented");
+  RMW_SET_ERROR_MSG("rmw_get_serialized_message_size not implemented for rmw_email_cpp");
   return RMW_RET_UNSUPPORTED;
 }
 
@@ -36,6 +36,9 @@ extern "C" rmw_ret_t rmw_serialize(
   rmw_serialized_message_t * serialized_message)
 {
   // TODO(christophebedard) figure out
+  static_cast<void>(ros_message);
+  static_cast<void>(type_support);
+  static_cast<void>(serialized_message);
   // serialized_message->
   return RMW_RET_OK;
 }
@@ -46,5 +49,8 @@ extern "C" rmw_ret_t rmw_deserialize(
   void * ros_message)
 {
   // TODO(christophebedard) figure out
+  static_cast<void>(serialized_message);
+  static_cast<void>(type_support);
+  static_cast<void>(ros_message);
   return RMW_RET_OK;
 }

--- a/rmw_email_cpp/src/rmw_take.cpp
+++ b/rmw_email_cpp/src/rmw_take.cpp
@@ -42,7 +42,7 @@ static rmw_ret_t _rmw_take(
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
   RMW_CHECK_ARGUMENT_FOR_NULL(ros_message, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(taken, RMW_RET_INVALID_ARGUMENT);
-  RMW_CHECK_ARGUMENT_FOR_NULL(allocation, RMW_RET_INVALID_ARGUMENT);
+  static_cast<void>(allocation);
 
   auto rmw_email_sub = static_cast<rmw_email_sub_t *>(subscription->data);
   email::Subscriber * email_sub = rmw_email_sub->email_sub;

--- a/rmw_email_cpp/src/rmw_wait.cpp
+++ b/rmw_email_cpp/src/rmw_wait.cpp
@@ -118,10 +118,14 @@ extern "C" rmw_ret_t rmw_wait(
   }
 
   /// Wait
-  auto wait_timeout_chrono =
-    std::chrono::seconds(wait_timeout->sec) + std::chrono::nanoseconds(wait_timeout->nsec);
-  auto wait_timeout_chrono_ms =
-    std::chrono::duration_cast<std::chrono::milliseconds>(wait_timeout_chrono);
+  // If a timeout isn't provided, we wait forever until ready
+  std::chrono::milliseconds wait_timeout_chrono_ms = std::chrono::milliseconds(-1);
+  if (wait_timeout) {
+    auto wait_timeout_chrono =
+      std::chrono::seconds(wait_timeout->sec) + std::chrono::nanoseconds(wait_timeout->nsec);
+    auto wait_timeout_chrono_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(wait_timeout_chrono);
+  }
   const bool timedout = email_waitset->wait(wait_timeout_chrono_ms);
 
   /// Set elements that were not triggered/that are not ready to nullptr in the arrays


### PR DESCRIPTION
* `allocation` in `rmw_take` is mostly unused
* some warnings
* `wait_timeout` in `rmw_wait` can be `nullptr`; in that case, we have to wait forever

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>