### PR TITLE
Handle rmw events correctly in rmw_wait()

### DIFF
--- a/rmw_email_cpp/src/rmw_event.cpp
+++ b/rmw_email_cpp/src/rmw_event.cpp
@@ -19,7 +19,6 @@
 #include "rmw/types.h"
 
 #include "rmw_email_cpp/identifier.hpp"
-// #include "rmw_email_cpp/types.hpp"
 
 static rmw_ret_t _init_rmw_event(
   rmw_event_t * rmw_event,
@@ -35,7 +34,7 @@ static rmw_ret_t _init_rmw_event(
     email_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
-  // TODO(christophebedard) figure out
+  // Do nothing else
 
   rmw_event->implementation_identifier = implementation_identifier;
   rmw_event->data = data;
@@ -94,6 +93,6 @@ extern "C" rmw_ret_t rmw_take_event(
   RMW_CHECK_ARGUMENT_FOR_NULL(event_info, RMW_RET_ERROR);
   RMW_CHECK_ARGUMENT_FOR_NULL(taken, RMW_RET_ERROR);
 
-  // TODO(christophebedard) figure out
+  // Do nothing, should not be called because there shouldn't be any events
   return RMW_RET_OK;
 }

--- a/rmw_email_cpp/src/rmw_wait.cpp
+++ b/rmw_email_cpp/src/rmw_wait.cpp
@@ -113,9 +113,7 @@ extern "C" rmw_ret_t rmw_wait(
       email_waitset->add_server(rmw_email_server->email_server);
     }
   }
-  if (events) {
-    // TODO(christophebedard)
-  }
+  // Do nothing with events
 
   /// Wait
   // If a timeout isn't provided, we wait forever until ready
@@ -166,7 +164,10 @@ extern "C" rmw_ret_t rmw_wait(
     }
   }
   if (events) {
-    // TODO(christophebedard)
+    // Just set everything to nullptr since we didn't actually wait on these, so none are ready
+    for (size_t i = 0u; i < events->event_count; i++) {
+      events->events[i] = nullptr;
+    }
   }
 
   return timedout ? RMW_RET_TIMEOUT : RMW_RET_OK;


### PR DESCRIPTION
We must set all events to `nullptr` since we didn't actually wait on them, otherwise it's as if they're all always ready.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>