### PR TITLE
Switch service request sequence number to int64_t

### DIFF
--- a/email/include/email/service_client.hpp
+++ b/email/include/email/service_client.hpp
@@ -61,7 +61,7 @@ public:
    */
   EMAIL_PUBLIC
   void
-  send_request(const std::string & request, const uint32_t sequence_number);
+  send_request(const std::string & request, const SequenceNumber sequence_number);
 
   /// Send request.
   /**
@@ -71,7 +71,7 @@ public:
    * \return the sequence_number to use for getting the corresponding response
    */
   EMAIL_PUBLIC
-  uint32_t
+  SequenceNumber
   send_request(const std::string & request);
 
   /// Check if the client has an available response to a request.
@@ -81,11 +81,11 @@ public:
    */
   EMAIL_PUBLIC
   bool
-  has_response(const uint32_t sequence_number);
+  has_response(const SequenceNumber sequence_number);
 
   /// Check if the client has an available response to any request.
   /**
-   * Note: `has_response(uint32_t)` should be used instead.
+   * Note: `has_response(SequenceNumber)` should be used instead.
    *
    * \return true if there is an available response, false otherwise
    */
@@ -100,7 +100,7 @@ public:
    */
   EMAIL_PUBLIC
   std::optional<std::string>
-  get_response(const uint32_t sequence_number);
+  get_response(const SequenceNumber sequence_number);
 
   /// Get a response with info if there is one.
   /**
@@ -109,7 +109,7 @@ public:
    */
   EMAIL_PUBLIC
   std::optional<std::pair<std::string, ServiceInfo>>
-  get_response_with_info(const uint32_t sequence_number);
+  get_response_with_info(const SequenceNumber sequence_number);
 
 private:
   EMAIL_DISABLE_COPY(ServiceClient)

--- a/email/include/email/service_handler.hpp
+++ b/email/include/email/service_handler.hpp
@@ -42,7 +42,7 @@ namespace email
 class ServiceHandler : public EmailHandler
 {
 public:
-  using ServiceResponseMap = SafeMap<uint32_t, std::pair<struct EmailData, ServiceInfo>>;
+  using ServiceResponseMap = SafeMap<SequenceNumber, std::pair<struct EmailData, ServiceInfo>>;
   using RequestQueue = SafeQueue<std::pair<struct EmailData, ServiceInfo>>;
 
   /// Constructor.
@@ -78,15 +78,6 @@ public:
    */
   void
   virtual handle(const struct EmailData & data) const;
-
-  /// Extract request sequence number from email data.
-  /**
-   * \param data the email data
-   * \return the sequence number, or `std::nullopt` if there is none
-   */
-  static
-  std::optional<uint32_t>
-  extract_sequence_number(const struct EmailData & data);
 
   /// Custom header name for service request sequence number.
   /**

--- a/email/include/email/service_info.hpp
+++ b/email/include/email/service_info.hpp
@@ -26,6 +26,9 @@
 namespace email
 {
 
+/// Sequence number type.
+typedef int64_t SequenceNumber;
+
 /// Service info container.
 /**
  * Contains metadata about a received service request or response.
@@ -39,7 +42,7 @@ public:
     const Timestamp & source_timestamp,
     const Timestamp & received_timestamp,
     const Gid & client_gid,
-    const uint32_t sequence_number);
+    const SequenceNumber sequence_number);
 
   EMAIL_PUBLIC
   ServiceInfo(const ServiceInfo &) = default;
@@ -64,7 +67,7 @@ public:
 
   /// Get the request sequence number.
   EMAIL_PUBLIC
-  uint32_t
+  SequenceNumber
   sequence_number() const;
 
   /// Get a ServiceInfo object from email headers.
@@ -84,7 +87,7 @@ public:
 
 private:
   const CommunicationInfo base_info_;
-  const uint32_t sequence_number_;
+  const SequenceNumber sequence_number_;
 };
 
 }  // namespace email

--- a/email/include/email/service_request.hpp
+++ b/email/include/email/service_request.hpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "email/gid.hpp"
+#include "email/service_info.hpp"
 
 namespace email
 {
@@ -26,11 +27,11 @@ namespace email
 struct ServiceRequestId
 {
   /// Sequence number of the request.
-  uint32_t sequence_number;
+  SequenceNumber sequence_number;
   /// GID of the service client that made the request.
   Gid client_gid;
   /// Constructor.
-  ServiceRequestId(const uint32_t sequence_number_, const Gid & client_gid_)
+  ServiceRequestId(const SequenceNumber sequence_number_, const Gid & client_gid_)
   : sequence_number(sequence_number_),
     client_gid(client_gid_)
   {}
@@ -47,7 +48,7 @@ struct ServiceRequest
   std::string content;
   /// Constructor.
   ServiceRequest(
-    const uint32_t sequence_number_,
+    const SequenceNumber sequence_number_,
     const Gid & client_gid_,
     const std::string & content_)
   : id(sequence_number_, client_gid_),

--- a/email/include/email/service_server.hpp
+++ b/email/include/email/service_server.hpp
@@ -92,7 +92,7 @@ private:
   std::shared_ptr<Logger> logger_;
   ServiceHandler::RequestQueue::SharedPtr requests_;
   std::shared_ptr<EmailSender> sender_;
-  std::map<uint32_t, struct EmailData> requests_raw_;
+  std::map<SequenceNumber, struct EmailData> requests_raw_;
 };
 
 }  // namespace email

--- a/email/include/email/wait.hpp
+++ b/email/include/email/wait.hpp
@@ -22,6 +22,7 @@
 
 #include "email/message_info.hpp"
 #include "email/service_client.hpp"
+#include "email/service_info.hpp"
 #include "email/service_request.hpp"
 #include "email/service_server.hpp"
 #include "email/subscription.hpp"
@@ -92,19 +93,19 @@ wait_for_message(
 EMAIL_PUBLIC
 std::pair<std::string, ServiceInfo>
 wait_for_response_with_info(
-  const uint32_t sequence_number,
+  const SequenceNumber sequence_number,
   ServiceClient * client,
   const std::chrono::milliseconds timeout = std::chrono::milliseconds(-1));
 
 /// Get a service reponse with info, waiting until it is available.
 /**
  * \see wait_for_response_with_info(
- *    const uint32_t, ServiceClient *, const std::chrono::milliseconds)
+ *    const SequenceNumber, ServiceClient *, const std::chrono::milliseconds)
  */
 EMAIL_PUBLIC
 std::string
 wait_for_response_with_info(
-  const uint32_t sequence_number,
+  const SequenceNumber sequence_number,
   std::shared_ptr<ServiceClient> client,
   const std::chrono::milliseconds timeout = std::chrono::milliseconds(-1));
 
@@ -120,18 +121,18 @@ wait_for_response_with_info(
 EMAIL_PUBLIC
 std::string
 wait_for_response(
-  const uint32_t sequence_number,
+  const SequenceNumber sequence_number,
   ServiceClient * client,
   const std::chrono::milliseconds timeout = std::chrono::milliseconds(-1));
 
 /// Get a service reponse, waiting until it is available.
 /**
- * \see wait_for_response(const uint32_t, ServiceClient *, const std::chrono::milliseconds)
+ * \see wait_for_response(const SequenceNumber, ServiceClient *, const std::chrono::milliseconds)
  */
 EMAIL_PUBLIC
 std::string
 wait_for_response(
-  const uint32_t sequence_number,
+  const SequenceNumber sequence_number,
   std::shared_ptr<ServiceClient> client,
   const std::chrono::milliseconds timeout = std::chrono::milliseconds(-1));
 

--- a/email/src/service_client.cpp
+++ b/email/src/service_client.cpp
@@ -49,7 +49,7 @@ ServiceClient::~ServiceClient()
 }
 
 void
-ServiceClient::send_request(const std::string & request, const uint32_t sequence_number)
+ServiceClient::send_request(const std::string & request, const SequenceNumber sequence_number)
 {
   // Publisher will add source timestamp
   const EmailHeaders headers = {
@@ -58,18 +58,18 @@ ServiceClient::send_request(const std::string & request, const uint32_t sequence
   pub_.publish(request, headers);
 }
 
-uint32_t
+SequenceNumber
 ServiceClient::send_request(const std::string & request)
 {
-  static std::atomic_uint32_t sequence_number_counter = 0u;
-  const uint32_t sequence_number = sequence_number_counter++;
+  static std::atomic_int64_t sequence_number_counter = 0l;
+  const SequenceNumber sequence_number = sequence_number_counter++;
   logger_->debug("creating request with sequence number: {}", sequence_number);
   send_request(request, sequence_number);
   return sequence_number;
 }
 
 bool
-ServiceClient::has_response(const uint32_t sequence_number)
+ServiceClient::has_response(const SequenceNumber sequence_number)
 {
   return responses_->contains(sequence_number);
 }
@@ -81,7 +81,7 @@ ServiceClient::has_response()
 }
 
 std::optional<std::string>
-ServiceClient::get_response(const uint32_t sequence_number)
+ServiceClient::get_response(const SequenceNumber sequence_number)
 {
   auto response_with_info_opt = get_response_with_info(sequence_number);
   if (!response_with_info_opt) {
@@ -91,7 +91,7 @@ ServiceClient::get_response(const uint32_t sequence_number)
 }
 
 std::optional<std::pair<std::string, ServiceInfo>>
-ServiceClient::get_response_with_info(const uint32_t sequence_number)
+ServiceClient::get_response_with_info(const SequenceNumber sequence_number)
 {
   auto it = responses_->find(sequence_number);
   if (it == responses_->cend()) {

--- a/email/src/service_info.cpp
+++ b/email/src/service_info.cpp
@@ -29,7 +29,7 @@ ServiceInfo::ServiceInfo(
   const Timestamp & source_timestamp,
   const Timestamp & received_timestamp,
   const Gid & client_gid,
-  const uint32_t sequence_number)
+  const SequenceNumber sequence_number)
 : base_info_(source_timestamp, received_timestamp, client_gid),
   sequence_number_(sequence_number)
 {}
@@ -54,7 +54,7 @@ ServiceInfo::client_gid() const
   return base_info_.source_gid();
 }
 
-uint32_t
+SequenceNumber
 ServiceInfo::sequence_number() const
 {
   return sequence_number_;
@@ -74,12 +74,12 @@ ServiceInfo::from_headers(const EmailHeaders & headers)
     return std::nullopt;
   }
   // If the header is there, the value *should* be convertible to a sequence number
-  auto sequence_number_opt = utils::optional_stoul(sequence_number_str_opt.value());
+  auto sequence_number_opt = utils::optional_stoll(sequence_number_str_opt.value());
   if (!sequence_number_opt) {
     // TODO(christophebedard) log
     return std::nullopt;
   }
-  const uint32_t sequence_number = sequence_number_opt.value();
+  const SequenceNumber sequence_number = sequence_number_opt.value();
   return ServiceInfo(
     base_info_opt.value().source_timestamp(),
     base_info_opt.value().received_timestamp(),

--- a/email/src/service_server.cpp
+++ b/email/src/service_server.cpp
@@ -76,17 +76,11 @@ ServiceServer::get_request_with_info()
   const auto request = requests_->dequeue();
   const auto email_data = request.first;
   const auto info = request.second;
-  auto sequence_number = ServiceHandler::extract_sequence_number(email_data);
-  if (!sequence_number) {
-    // Should not happen because ServiceHandler should filter those out
-    logger_->error("request without a sequence number");
-    return std::nullopt;
-  }
   // Put raw request data in a map so that we can
   // fetch & use it when sending our response
-  requests_raw_.insert({sequence_number.value(), email_data});
+  requests_raw_.insert({info.sequence_number(), email_data});
   return {{
-    ServiceRequest(sequence_number.value(), info.client_gid(), email_data.content.body), info}};
+    ServiceRequest(info.sequence_number(), info.client_gid(), email_data.content.body), info}};
 }
 
 void

--- a/email/src/wait.cpp
+++ b/email/src/wait.cpp
@@ -67,7 +67,7 @@ wait_for_message(
 
 std::pair<std::string, ServiceInfo>
 wait_for_response_with_info(
-  const uint32_t sequence_number,
+  const SequenceNumber sequence_number,
   ServiceClient * client,
   const std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
 {
@@ -81,7 +81,7 @@ wait_for_response_with_info(
 
 std::pair<std::string, ServiceInfo>
 wait_for_response_with_info(
-  const uint32_t sequence_number,
+  const SequenceNumber sequence_number,
   std::shared_ptr<ServiceClient> client,
   const std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
 {
@@ -90,7 +90,7 @@ wait_for_response_with_info(
 
 std::string
 wait_for_response(
-  const uint32_t sequence_number,
+  const SequenceNumber sequence_number,
   ServiceClient * client,
   const std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
 {
@@ -99,7 +99,7 @@ wait_for_response(
 
 std::string
 wait_for_response(
-  const uint32_t sequence_number,
+  const SequenceNumber sequence_number,
   std::shared_ptr<ServiceClient> client,
   const std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
 {


### PR DESCRIPTION
Closes #210

This also removes `ServiceHandler::extract_sequence_number` since it's handled by `ServiceInfo::from_headers` anyway.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>