### PR TITLE
Discard additional service responses for the same request

### DIFF
--- a/email/include/email/email/handler.hpp
+++ b/email/include/email/email/handler.hpp
@@ -34,7 +34,7 @@ public:
    * \param data the new email data
    */
   void
-  virtual handle(const struct EmailData & data) const = 0;
+  virtual handle(const struct EmailData & data) = 0;
 
 protected:
   /// Constructor.

--- a/email/include/email/subscription_handler.hpp
+++ b/email/include/email/subscription_handler.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
 #include "email/email/handler.hpp"
@@ -67,14 +68,14 @@ public:
    * \param data the new email data
    */
   void
-  virtual handle(const struct EmailData & data) const;
+  virtual handle(const struct EmailData & data);
 
 private:
   EMAIL_DISABLE_COPY(SubscriptionHandler)
 
   std::shared_ptr<Logger> logger_;
   mutable std::mutex subscriptions_mutex_;
-  std::multimap<std::string, MessageQueue::SharedPtr> subscriptions_;
+  std::unordered_multimap<std::string, MessageQueue::SharedPtr> subscriptions_;
 };
 
 }  // namespace email

--- a/email/src/service_server.cpp
+++ b/email/src/service_server.cpp
@@ -35,7 +35,7 @@ namespace email
 
 ServiceServer::ServiceServer(const std::string & service_name)
 : ServiceObject(service_name),
-  logger_(log::create("ServiceServer::" + service_name)),
+  logger_(log::get_or_create("ServiceServer::" + service_name)),
   requests_(std::make_shared<ServiceHandler::RequestQueue>()),
   sender_(get_global_context()->get_sender()),
   requests_raw_()

--- a/email/src/subscription_handler.cpp
+++ b/email/src/subscription_handler.cpp
@@ -63,7 +63,7 @@ SubscriptionHandler::register_subscription(
 }
 
 void
-SubscriptionHandler::handle(const struct EmailData & data) const
+SubscriptionHandler::handle(const struct EmailData & data)
 {
   logger_->debug("handling new email");
   const std::string & topic = data.content.subject;


### PR DESCRIPTION
This makes sure that additional responses (if multiple service servers respond) for the same service request (same client, same sequence number) are discarded.

This PR also switches to `std::unordered_map` & `std::unordered_multimap` for maps in `ServiceHandler` & `SubscriptionHandler.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>