### PR TITLE
Point dependencies.repos to yaml_cpp_vendor @ master

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -405,8 +405,8 @@ repositories:
     version: ros2
   ros2/yaml_cpp_vendor:
     type: git
-    url: https://github.com/christophebedard/yaml_cpp_vendor.git
-    version: fix-handling-of-flags-lists
+    url: https://github.com/ros2/yaml_cpp_vendor.git
+    version: master
   christophebedard/dynamic_message_introspection:
     type: git
     url: https://github.com/christophebedard/dynamic_message_introspection.git


### PR DESCRIPTION
Since the PR was merged: https://github.com/ros2/yaml_cpp_vendor/pull/24

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>