### PR TITLE
Replace custom REPO_TOKEN with default GITHUB_TOKEN for CI + DCO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         vcs-repo-file-url: |
           ${{ github.workspace }}/dependencies.repos
           ${{ matrix.build-type == 'source' && 'https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos' || '' }}
-        import-token: ${{ secrets.REPO_TOKEN }}
+        import-token: ${{ secrets.GITHUB_TOKEN }}
         colcon-defaults: |
           {
             "build": {

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: 3.8
     - name: Check DCO
       env:
-        GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         pip3 install -U dco-check
         dco-check --verbose


### PR DESCRIPTION
This works with `action-ros-ci` thanks to https://github.com/ros-tooling/action-ros-ci/pull/692.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>