### PR TITLE
Append '-poll' to polling thread name instead

### DIFF
--- a/email/include/email/utils.hpp
+++ b/email/include/email/utils.hpp
@@ -151,7 +151,18 @@ EMAIL_PUBLIC
 std::optional<int64_t>
 optional_stoll(const std::string & str);
 
-/// Set thread name if the platform supports it.
+/// Get the name of the current thread if the platform supports it.
+/**
+ * The platform might have a minimum buffer length requirement (16 for Linux).
+ *
+ * \param name the buffer in which to write the name
+ * \param len the length of the buffer
+ */
+EMAIL_PUBLIC
+void
+thread_get_name(char * name, size_t len);
+
+/// Set the name of the current thread if the platform supports it.
 /**
  * The name might be truncated if the platform has a name length limit.
  *
@@ -160,6 +171,16 @@ optional_stoll(const std::string & str);
 EMAIL_PUBLIC
 void
 thread_set_name(const char * name);
+
+/// Append a suffix to name of the current thread if the platform supports it.
+/**
+ * The current name will be truncated to fit the suffix if needed.
+ *
+ * \param suffix the suffix
+ */
+EMAIL_PUBLIC
+void
+thread_append_name(const char * suffix);
 
 }  // namespace utils
 }  // namespace email

--- a/email/src/email/polling_manager.cpp
+++ b/email/src/email/polling_manager.cpp
@@ -84,7 +84,7 @@ PollingManager::shutdown()
 void
 PollingManager::poll_thread()
 {
-  utils::thread_set_name("email-polling");
+  utils::thread_append_name("-poll");
   logger_->debug("poll_thread start");
   while (!do_shutdown_.load()) {
     // Get new email


### PR DESCRIPTION
Follow-up to #224

Example:

```
0x00007ffff58f537d in email::WaitSet::wait (this=0x5555555fc290, timeout=...) at /home/chris/ros2_ws/src/rmw_email/email/src/wait_set.cpp:165
165           if (!servers_ready[i] && servers_[i]->has_request()) {
(gdb) info threads
  Id   Target Id                                             Frame 
* 1    Thread 0x7ffff6a46000 (LWP 4036738) "add_two_ints_se" 0x00007ffff58f537d in email::WaitSet::wait (this=0x5555555fc290, timeout=...)
    at /home/chris/ros2_ws/src/rmw_email/email/src/wait_set.cpp:165
  2    Thread 0x7ffff6a3f700 (LWP 4036750) "add_two_ints_se" __libc_recvmsg (flags=0, msg=0x7ffff6a3d840, fd=3) at ../sysdeps/unix/sysv/linux/recvmsg.c:28
  3    Thread 0x7ffff623e700 (LWP 4036751) "add_two_ints_se" syscall () at ../sysdeps/unix/sysv/linux/x86_64/syscall.S:38
  4    Thread 0x7fffeffff700 (LWP 4036753) "add_two_ints_se" futex_abstimed_wait_cancelable (private=0, abstime=0x0, clockid=0, expected=0, 
    futex_word=0x7ffff7fc4540 <rclcpp::SignalHandler::signal_handler_sem_>) at ../sysdeps/nptl/futex-internal.h:320
  5    Thread 0x7fffef7fe700 (LWP 4036756) "add_two_in-poll" 0x00007ffff6fdaaff in __GI___poll (fds=0x7fffef7fcc10, nfds=2, timeout=1000) at ../sysdeps/unix/sysv/linux/poll.c:29
```

See thread name for 4036756: `"add_two_in-poll"`.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>