### PR TITLE
Fix timer starvation because of WaitSet::wait always blocking

### DIFF
--- a/rmw_email_cpp/src/rmw_wait.cpp
+++ b/rmw_email_cpp/src/rmw_wait.cpp
@@ -121,7 +121,7 @@ extern "C" rmw_ret_t rmw_wait(
   if (wait_timeout) {
     auto wait_timeout_chrono =
       std::chrono::seconds(wait_timeout->sec) + std::chrono::nanoseconds(wait_timeout->nsec);
-    auto wait_timeout_chrono_ms =
+    wait_timeout_chrono_ms =
       std::chrono::duration_cast<std::chrono::milliseconds>(wait_timeout_chrono);
   }
   const bool timedout = email_waitset->wait(wait_timeout_chrono_ms);


### PR DESCRIPTION
Fixes #238

`wait_timeout_chrono_ms` was shadowed so the value was always `-1`, i.e., blocking indefinitely. This meant that, if nothing made the wait operation end (like getting a new message), the wait operation would never end and timers would never be executed. Timeout values are chosen carefully in `rcl` so that timers aren't starved: https://github.com/ros2/rcl/blob/28b1c293ff7d9667e23e9789bb1caf3bd06a751b/rcl/src/rcl/wait.c#L540 but this bug was messing with that value.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>