### PR TITLE
Fix doc job

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -32,16 +32,19 @@ jobs:
         ref: gh-pages
         fetch-depth: 0
         path: gh-pages/
-    - name: Insert token into gen_docs config to clone repo
-      run: |
-        sed -i -e 's*https://github.com/christophebedard/rmw_email.git*https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/christophebedard/rmw_email.git*g' gh-pages/gen_docs.yml
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        ref: master
+        fetch-depth: 0
+        path: repos/master/
     - name: Gen docs
       run: |
-        python3 gen_docs/gen_docs.py --config gh-pages/gen_docs.yml
+        python3 gen_docs/gen_docs.py --config gh-pages/gen_docs.yml --skip-clone
     - name: Copy docs to gh-pages
       run: |
-        rm -rf gh-pages/email/
-        cp -R output/master/ gh-pages/api/
+        rm -rf gh-pages/api/
+        mv -T output/master/ gh-pages/api/
     - name: Commit and push to gh-pages branch
       run: |
         cd gh-pages


### PR DESCRIPTION
Manually clone repo, otherwise it just doesn't want to be cloned. It's a private repo and the auth-related configs for other `actions/checkout` steps probably interfere.

It'll be easier once the repo is made public.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>