### PR TITLE
Fix wait_for_response_with_info() declaration

### DIFF
--- a/email/include/email/wait.hpp
+++ b/email/include/email/wait.hpp
@@ -103,7 +103,7 @@ wait_for_response_with_info(
  *    const SequenceNumber, ServiceClient *, const std::chrono::milliseconds)
  */
 EMAIL_PUBLIC
-std::string
+std::pair<std::string, ServiceInfo>
 wait_for_response_with_info(
   const SequenceNumber sequence_number,
   std::shared_ptr<ServiceClient> client,


### PR DESCRIPTION
Didn't seem to affect anything because it probably wasn't used.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>