### PR TITLE
Rename ServiceResponseMap to ResponseMap

### DIFF
--- a/email/include/email/service_client.hpp
+++ b/email/include/email/service_client.hpp
@@ -125,7 +125,7 @@ private:
   EMAIL_DISABLE_COPY(ServiceClient)
 
   std::shared_ptr<Logger> logger_;
-  ServiceHandler::ServiceResponseMap::SharedPtr responses_;
+  ServiceHandler::ResponseMap::SharedPtr responses_;
   Publisher pub_;
 };
 

--- a/email/include/email/service_handler.hpp
+++ b/email/include/email/service_handler.hpp
@@ -47,7 +47,7 @@ namespace email
 class ServiceHandler : public EmailHandler
 {
 public:
-  using ServiceResponseMap = SafeMap<SequenceNumber, std::pair<struct EmailData, ServiceInfo>>;
+  using ResponseMap = SafeMap<SequenceNumber, std::pair<struct EmailData, ServiceInfo>>;
   using RequestQueue = SafeQueue<std::pair<struct EmailData, ServiceInfo>>;
 
   /// Constructor.
@@ -63,7 +63,7 @@ public:
   void
   register_service_client(
     const Gid & gid,
-    ServiceResponseMap::SharedPtr response_map);
+    ResponseMap::SharedPtr response_map);
 
   /// Register a service server with the handler.
   /**
@@ -96,7 +96,7 @@ private:
 
   std::shared_ptr<Logger> logger_;
   mutable std::mutex mutex_clients_;
-  std::unordered_map<GidValue, ServiceResponseMap::SharedPtr> clients_;
+  std::unordered_map<GidValue, ResponseMap::SharedPtr> clients_;
   std::unordered_map<GidValue, SequenceNumber> clients_last_seq_;
   mutable std::mutex mutex_servers_;
   std::unordered_multimap<std::string, RequestQueue::SharedPtr> servers_;

--- a/email/src/service_client.cpp
+++ b/email/src/service_client.cpp
@@ -34,7 +34,7 @@ namespace email
 ServiceClient::ServiceClient(const std::string & service_name)
 : ServiceObject(service_name),
   logger_(log::get_or_create("ServiceClient::" + service_name)),
-  responses_(std::make_shared<ServiceHandler::ServiceResponseMap>()),
+  responses_(std::make_shared<ServiceHandler::ResponseMap>()),
   pub_(get_service_name())
 {
   logger_->debug("created with GID: {}", get_gid());

--- a/email/src/service_handler.cpp
+++ b/email/src/service_handler.cpp
@@ -60,7 +60,7 @@ ServiceHandler::~ServiceHandler()
 void
 ServiceHandler::register_service_client(
   const Gid & gid,
-  ServiceResponseMap::SharedPtr response_map)
+  ResponseMap::SharedPtr response_map)
 {
   {
     std::scoped_lock<std::mutex> lock(mutex_clients_);


### PR DESCRIPTION
It's more consistent with `RequestQueue` right next to it.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>