### PR TITLE
Fix segfault in context shut down by fixing init/fini logic

### DIFF
--- a/email/include/email/context.hpp
+++ b/email/include/email/context.hpp
@@ -185,11 +185,14 @@ private:
   void
   init_common();
 
-  std::shared_ptr<Logger> logger_;
-  std::shared_ptr<Options> options_;
   bool is_valid_;
-  mutable bool is_receiver_init_;
-  mutable bool is_polling_manager_init_;
+  std::shared_ptr<Options> options_;
+  std::shared_ptr<Logger> logger_;
+  std::shared_ptr<EmailSender> sender_;
+  std::shared_ptr<EmailReceiver> receiver_;
+  std::shared_ptr<PollingManager> polling_manager_;
+  std::shared_ptr<SubscriptionHandler> subscription_handler_;
+  std::shared_ptr<ServiceHandler> service_handler_;
 };
 
 /// Get the global context.

--- a/email/include/email/curl/context.hpp
+++ b/email/include/email/curl/context.hpp
@@ -17,6 +17,7 @@
 
 #include <curl/curl.h>
 
+#include <atomic>
 #include <memory>
 #include <string>
 
@@ -100,6 +101,7 @@ private:
   const struct ConnectionInfo connection_info_;
   const std::string full_url_;
   bool curl_verbose_;
+  std::atomic_bool is_init_;
 };
 
 }  // namespace email

--- a/email/src/email/polling_manager.cpp
+++ b/email/src/email/polling_manager.cpp
@@ -78,7 +78,7 @@ PollingManager::shutdown()
   logger_->debug("shutting down");
   receiver_->shutdown();
   if (has_started()) {
-    do_shutdown_ = true;
+    do_shutdown_.store(true);
     if (thread_.joinable()) {
       thread_.join();
     }

--- a/email/src/email/receiver.cpp
+++ b/email/src/email/receiver.cpp
@@ -69,7 +69,7 @@ EmailReceiver::init_options()
 void
 EmailReceiver::shutdown()
 {
-  do_shutdown_ = true;
+  do_shutdown_.store(true);
 }
 
 std::optional<struct EmailData>
@@ -135,6 +135,10 @@ EmailReceiver::execute(
   std::optional<std::string> url_options,
   std::optional<std::string> custom_request)
 {
+  if (do_shutdown_.load()) {
+    return std::nullopt;
+  }
+
   std::string request_url(context_.get_full_url());
   if (url_options) {
     request_url += url_options.value();

--- a/email/src/email/sender.cpp
+++ b/email/src/email/sender.cpp
@@ -140,7 +140,7 @@ EmailSender::send_payload(const std::string & payload)
   // Reset upload data
   upload_ctx_.payload = payload.c_str();
   // TODO(christophebedard) use 'uz' suffix when switching to C++23
-  upload_ctx_.lines_read = 0u;
+  upload_ctx_.lines_read = 0UL;
   if (!context_.execute()) {
     return false;
   }


### PR DESCRIPTION
Part of #247

This doesn't solve everything in #247, but it fixes the segfault when the `email` context gets shut down by `rmw`.

There's still *sometimes* a segfault on shutdown inside `email::EmailReceiver::execute`/`email::CurlContext::execute`/`curl_easy_perform`. It might be still trying to execute a request when we're trying to shut down.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>