### PR TITLE
Add polling period option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ As for the values:
            - another@email.com
          ```
       * `to` must be defined and must contain at least one email address, but `cc` and `bcc` are optional
+   * `polling-period`: email polling period in nanoseconds
+      * optional; by default, polling will be done as fast as possible
 
 Using the same configuration file with the same email for the `username` and `to` fields (i.e., same email address for sending & receiving) for all your executables will work.
 Alternatively, you can use two different configuration files for two different executables, e.g., if they're sending emails to each other.

--- a/email/doc/design.md
+++ b/email/doc/design.md
@@ -122,7 +122,7 @@ class EmailSender {
 CurlExecutor <|-- EmailSender
 
 class EmailReceiver {
-   +get_email(): optional<EmailData>
+   +get_email(nanoseconds polling_period): optional<EmailData>
    #init_options() {abstract}
    -get_nextuid(): optional<int>
    -get_email_from_uid(int): optional<EmailData>

--- a/email/email.yml
+++ b/email/email.yml
@@ -8,3 +8,4 @@ email:
     to:
     cc:
     bcc:
+  polling-period:

--- a/email/include/email/email/polling_manager.hpp
+++ b/email/include/email/email/polling_manager.hpp
@@ -20,6 +20,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
 #include <string>
 #include <thread>
 #include <vector>
@@ -43,8 +44,11 @@ public:
   /// Constructor.
   /**
    * \param receiver the email receiver to use for getting emails
+   * \param polling_period the polling period, or `std::optional` to use the default value
    */
-  explicit PollingManager(std::shared_ptr<EmailReceiver> receiver);
+  explicit PollingManager(
+    std::shared_ptr<EmailReceiver> receiver,
+    const std::optional<std::chrono::nanoseconds> polling_period);
 
   ~PollingManager();
 
@@ -83,14 +87,13 @@ private:
   poll_thread();
 
   std::shared_ptr<EmailReceiver> receiver_;
+  const std::optional<std::chrono::nanoseconds> polling_period_;
   bool has_started_;
   std::atomic_bool do_shutdown_;
   std::thread thread_;
   std::mutex handlers_mutex_;
   std::vector<HandlerFunction> handlers_;
   std::shared_ptr<Logger> logger_;
-
-  static constexpr auto POLLING_PERIOD = std::chrono::milliseconds(1);
 };
 
 }  // namespace email

--- a/email/include/email/email/receiver.hpp
+++ b/email/include/email/email/receiver.hpp
@@ -62,11 +62,22 @@ public:
 
   /// Get a new email.
   /**
+   * This function fetches a new email through polling.
+   *
+   * The caller can specify a polling period, which will be used as a target polling rate.
+   * This means that, if the internal polling call takes more time than the polling period,
+   * the next call will be executed right away.
+   *
+   * If the polling period value is equal to 0, the sleep call will be skipped,
+   * and polling will be done as fast as possible.
+   * This is the default value.
+   *
+   * \param polling_period the polling period
    * \return the new email, or `std::nullopt` if it failed
    */
   EMAIL_PUBLIC
   std::optional<struct EmailData>
-  get_email();
+  get_email(std::optional<std::chrono::nanoseconds> polling_period = std::nullopt);
 
 protected:
   virtual

--- a/email/include/email/options.hpp
+++ b/email/include/email/options.hpp
@@ -15,6 +15,7 @@
 #ifndef EMAIL__OPTIONS_HPP_
 #define EMAIL__OPTIONS_HPP_
 
+#include <chrono>
 #include <memory>
 #include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
 #include <regex>
@@ -44,12 +45,15 @@ public:
    * \param user_info the user info
    * \param recipients the recipients
    * \param curl_verbose the curl verbose status
+   * \param polling_period the polling period
    */
   EMAIL_PUBLIC
   Options(
     UserInfo::SharedPtrConst user_info,
     EmailRecipients::SharedPtrConst recipients,
-    bool curl_verbose);
+    const bool curl_verbose,
+    const std::optional<std::chrono::nanoseconds> polling_period);
+
   EMAIL_PUBLIC
   ~Options();
 
@@ -76,6 +80,14 @@ public:
   EMAIL_PUBLIC
   bool
   curl_verbose() const;
+
+  /// Get the polling period value.
+  /**
+   * \return the polling period
+   */
+  EMAIL_PUBLIC
+  std::optional<std::chrono::nanoseconds>
+  polling_period() const;
 
   /// Parse options from CLI arguments.
   /**
@@ -124,7 +136,8 @@ private:
 
   UserInfo::SharedPtrConst user_info_;
   EmailRecipients::SharedPtrConst recipients_;
-  bool curl_verbose_;
+  const bool curl_verbose_;
+  const std::optional<std::chrono::nanoseconds> polling_period_;
 
   static constexpr const char * ENV_VAR_CURL_VERBOSE = "EMAIL_CURL_VERBOSE";
   static constexpr const char * ENV_VAR_CONFIG_FILE = "EMAIL_CONFIG_FILE";

--- a/email/src/context.cpp
+++ b/email/src/context.cpp
@@ -112,7 +112,7 @@ Context::init_common()
   receiver_->init();
 
   assert(!polling_manager_);
-  polling_manager_ = std::make_shared<PollingManager>(receiver_);
+  polling_manager_ = std::make_shared<PollingManager>(receiver_, options_->polling_period());
   polling_manager_->start();
 
   assert(!subscription_handler_);


### PR DESCRIPTION
Closes #189

This adds a polling period option for YAML config files that controls the polling rate in `EmailReceiver::get_email`.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>