### PR TITLE
Create abstract EmailSender and extract CurlEmailSender

### DIFF
--- a/email/CMakeLists.txt
+++ b/email/CMakeLists.txt
@@ -53,6 +53,7 @@ set(SOURCES
   src/context.cpp
   src/curl/context.cpp
   src/curl/executor.cpp
+  src/email/curl_sender.cpp
   src/email/handler.cpp
   src/email/payload_utils.cpp
   src/email/polling_manager.cpp

--- a/email/include/email/email/curl_sender.hpp
+++ b/email/include/email/email/curl_sender.hpp
@@ -1,0 +1,89 @@
+// Copyright 2020-2021 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EMAIL__EMAIL__CURL_SENDER_HPP_
+#define EMAIL__EMAIL__CURL_SENDER_HPP_
+
+#include <memory>
+#include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
+#include <string>
+
+#include "email/curl/executor.hpp"
+#include "email/email/info.hpp"
+#include "email/email/sender.hpp"
+#include "email/macros.hpp"
+#include "email/visibility_control.hpp"
+
+namespace email
+{
+
+/// Email sending wrapper for curl.
+/**
+ * Sets the options and executes commands to send emails with curl.
+ */
+class CurlEmailSender : public EmailSender, public CurlExecutor
+{
+public:
+  /// Constructor.
+  /**
+   * \param user_info the user information for sending emails
+   * \param recipients the email recipients
+   * \param curl_verbose the curl verbose status
+   */
+  EMAIL_PUBLIC
+  explicit CurlEmailSender(
+    UserInfo::SharedPtrConst user_info,
+    EmailRecipients::SharedPtrConst recipients,
+    const bool curl_verbose);
+
+  EMAIL_PUBLIC
+  virtual ~CurlEmailSender();
+
+protected:
+  virtual
+  bool
+  init_options();
+
+  /// Send payload.
+  /**
+   * \param payload the payload
+   * \return true if successful, false otherwise
+   */
+  virtual
+  bool
+  send_payload(const std::string & payload);
+
+private:
+  EMAIL_DISABLE_COPY(CurlEmailSender)
+
+  /// Read callback for curl upload.
+  static
+  size_t
+  read_payload_callback(void * ptr, size_t size, size_t nmemb, void * userp);
+
+  /// Utility struct for uploading data with curl.
+  struct UploadData
+  {
+    const char * payload;
+    size_t lines_read;
+  };
+
+  EmailRecipients::SharedPtrConst recipients_;
+  struct curl_slist * recipients_list_;
+  struct UploadData upload_ctx_;
+};
+
+}  // namespace email
+
+#endif  // EMAIL__EMAIL__CURL_SENDER_HPP_

--- a/email/src/context.cpp
+++ b/email/src/context.cpp
@@ -17,7 +17,9 @@
 #include <string>
 
 #include "email/context.hpp"
+#include "email/email/curl_sender.hpp"
 #include "email/email/info.hpp"
+#include "email/email/sender.hpp"
 #include "email/log.hpp"
 #include "email/utils.hpp"
 
@@ -99,11 +101,11 @@ Context::init_common()
   // Initialize in the right order: some objects might fetch
   // other objects from the context on creation or initialization
   assert(!sender_);
-  sender_ = std::make_shared<EmailSender>(
+  sender_ = std::make_shared<CurlEmailSender>(
     options_->get_user_info(),
     options_->get_recipients(),
     options_->curl_verbose());
-  sender_->init();
+  std::dynamic_pointer_cast<CurlEmailSender>(sender_)->init();
 
   assert(!receiver_);
   receiver_ = std::make_shared<EmailReceiver>(

--- a/email/src/email/curl_sender.cpp
+++ b/email/src/email/curl_sender.cpp
@@ -1,0 +1,126 @@
+// Copyright 2020-2021 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <curl/curl.h>
+
+#include <cstring>
+#include <memory>
+#include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
+#include <stdexcept>
+#include <string>
+
+#include "email/curl/executor.hpp"
+#include "email/email/curl_sender.hpp"
+#include "email/email/info.hpp"
+#include "email/email/payload_utils.hpp"
+#include "email/email/sender.hpp"
+#include "email/log.hpp"
+#include "email/utils.hpp"
+
+namespace email
+{
+
+CurlEmailSender::CurlEmailSender(
+  UserInfo::SharedPtrConst user_info,
+  EmailRecipients::SharedPtrConst recipients,
+  const bool curl_verbose)
+: EmailSender(user_info, recipients),
+  CurlExecutor(
+    {user_info->host_smtp, user_info->username, user_info->password},
+    {"smtps", 465},
+    curl_verbose),
+  recipients_(recipients),
+  recipients_list_(nullptr),
+  upload_ctx_()
+{}
+
+CurlEmailSender::~CurlEmailSender()
+{
+  if (recipients_list_) {
+    curl_slist_free_all(recipients_list_);
+    recipients_list_ = nullptr;
+  }
+  logger()->debug("destroying");
+}
+
+size_t
+CurlEmailSender::read_payload_callback(void * ptr, size_t size, size_t nmemb, void * userp)
+{
+  const size_t max_size = size * nmemb;
+  if ((0 == size) || (0 == nmemb) || (1 > max_size)) {
+    return 0;
+  }
+  struct UploadData * upload_ctx = (struct UploadData *)userp;
+  const char * data = &upload_ctx->payload[upload_ctx->lines_read];
+  if (!data) {
+    return 0;
+  }
+  size_t len = strlen(data);
+  if (len > max_size) {
+    len = max_size;
+    logger()->error("truncated to len={}", len);
+  }
+  memcpy(ptr, data, len);
+  upload_ctx->lines_read += len;
+  return len;
+}
+
+bool
+CurlEmailSender::init_options()
+{
+  curl_easy_setopt(context_.get_handle(), CURLOPT_URL, context_.get_full_url().c_str());
+  curl_easy_setopt(
+    context_.get_handle(), CURLOPT_MAIL_FROM, context_.get_connection_info().username.c_str());
+  // Add all destination emails to the list of recipients
+  if (0 == recipients_->to.size() + recipients_->cc.size() + recipients_->bcc.size()) {
+    logger()->critical("no recipients for CurlEmailSender");
+    return false;
+  }
+  for (auto & email_to : recipients_->to) {
+    recipients_list_ = curl_slist_append(recipients_list_, email_to.c_str());
+  }
+  for (auto & email_cc : recipients_->cc) {
+    recipients_list_ = curl_slist_append(recipients_list_, email_cc.c_str());
+  }
+  for (auto & email_bcc : recipients_->bcc) {
+    recipients_list_ = curl_slist_append(recipients_list_, email_bcc.c_str());
+  }
+  curl_easy_setopt(context_.get_handle(), CURLOPT_MAIL_RCPT, recipients_list_);
+  curl_easy_setopt(context_.get_handle(), CURLOPT_READFUNCTION, read_payload_callback);
+  curl_easy_setopt(context_.get_handle(), CURLOPT_READDATA, static_cast<void *>(&upload_ctx_));
+  curl_easy_setopt(context_.get_handle(), CURLOPT_UPLOAD, 1L);
+  // curl_easy_setopt(context_.get_handle(), CURLOPT_SSL_VERIFYPEER, 0L);
+  // curl_easy_setopt(context_.get_handle(), CURLOPT_SSL_VERIFYHOST, 0L);
+  return true;
+}
+
+bool
+CurlEmailSender::send_payload(const std::string & payload)
+{
+  if (!is_valid()) {
+    logger()->warn("not initialized!");
+    return false;
+  }
+  logger()->debug("PAYLOAD:\n{}", payload);
+  // Reset upload data
+  upload_ctx_.payload = payload.c_str();
+  // TODO(christophebedard) use 'uz' suffix when switching to C++23
+  upload_ctx_.lines_read = 0UL;
+  if (!context_.execute()) {
+    return false;
+  }
+  return true;
+}
+
+}  // namespace email

--- a/email/src/email/sender.cpp
+++ b/email/src/email/sender.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Christophe Bedard
+// Copyright 2021 Christophe Bedard
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,15 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <curl/curl.h>
-
-#include <cstring>
 #include <memory>
 #include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
-#include <stdexcept>
-#include <string>
 
-#include "email/curl/executor.hpp"
 #include "email/email/info.hpp"
 #include "email/email/payload_utils.hpp"
 #include "email/email/sender.hpp"
@@ -32,75 +26,14 @@ namespace email
 
 EmailSender::EmailSender(
   UserInfo::SharedPtrConst user_info,
-  EmailRecipients::SharedPtrConst recipients,
-  const bool curl_verbose)
-: CurlExecutor(
-    {user_info->host_smtp, user_info->username, user_info->password},
-    {"smtps", 465},
-    curl_verbose),
-  recipients_(recipients),
-  recipients_list_(nullptr),
-  upload_ctx_()
+  EmailRecipients::SharedPtrConst recipients)
+: user_info_(user_info),
+  recipients_(recipients)
 {}
 
 EmailSender::~EmailSender()
 {
-  if (recipients_list_) {
-    curl_slist_free_all(recipients_list_);
-    recipients_list_ = nullptr;
-  }
   logger()->debug("destroying");
-}
-
-size_t
-EmailSender::read_payload_callback(void * ptr, size_t size, size_t nmemb, void * userp)
-{
-  const size_t max_size = size * nmemb;
-  if ((0 == size) || (0 == nmemb) || (1 > max_size)) {
-    return 0;
-  }
-  struct UploadData * upload_ctx = (struct UploadData *)userp;
-  const char * data = &upload_ctx->payload[upload_ctx->lines_read];
-  if (!data) {
-    return 0;
-  }
-  size_t len = strlen(data);
-  if (len > max_size) {
-    len = max_size;
-    logger()->error("truncated to len={}", len);
-  }
-  memcpy(ptr, data, len);
-  upload_ctx->lines_read += len;
-  return len;
-}
-
-bool
-EmailSender::init_options()
-{
-  curl_easy_setopt(context_.get_handle(), CURLOPT_URL, context_.get_full_url().c_str());
-  curl_easy_setopt(
-    context_.get_handle(), CURLOPT_MAIL_FROM, context_.get_connection_info().username.c_str());
-  // Add all destination emails to the list of recipients
-  if (0 == recipients_->to.size() + recipients_->cc.size() + recipients_->bcc.size()) {
-    logger()->critical("no recipients for EmailSender");
-    return false;
-  }
-  for (auto & email_to : recipients_->to) {
-    recipients_list_ = curl_slist_append(recipients_list_, email_to.c_str());
-  }
-  for (auto & email_cc : recipients_->cc) {
-    recipients_list_ = curl_slist_append(recipients_list_, email_cc.c_str());
-  }
-  for (auto & email_bcc : recipients_->bcc) {
-    recipients_list_ = curl_slist_append(recipients_list_, email_bcc.c_str());
-  }
-  curl_easy_setopt(context_.get_handle(), CURLOPT_MAIL_RCPT, recipients_list_);
-  curl_easy_setopt(context_.get_handle(), CURLOPT_READFUNCTION, read_payload_callback);
-  curl_easy_setopt(context_.get_handle(), CURLOPT_READDATA, static_cast<void *>(&upload_ctx_));
-  curl_easy_setopt(context_.get_handle(), CURLOPT_UPLOAD, 1L);
-  // curl_easy_setopt(context_.get_handle(), CURLOPT_SSL_VERIFYPEER, 0L);
-  // curl_easy_setopt(context_.get_handle(), CURLOPT_SSL_VERIFYHOST, 0L);
-  return true;
 }
 
 bool
@@ -127,24 +60,6 @@ EmailSender::reply(
       content,
       additional_headers,
       email.message_id));
-}
-
-bool
-EmailSender::send_payload(const std::string & payload)
-{
-  if (!is_valid()) {
-    logger()->warn("not initialized!");
-    return false;
-  }
-  logger()->debug("PAYLOAD:\n{}", payload);
-  // Reset upload data
-  upload_ctx_.payload = payload.c_str();
-  // TODO(christophebedard) use 'uz' suffix when switching to C++23
-  upload_ctx_.lines_read = 0UL;
-  if (!context_.execute()) {
-    return false;
-  }
-  return true;
 }
 
 std::shared_ptr<Logger>

--- a/email_examples/src/send.cpp
+++ b/email_examples/src/send.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Christophe Bedard
+// Copyright 2020-2021 Christophe Bedard
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,15 +17,15 @@
 
 #include "email/context.hpp"
 #include "email/curl/info.hpp"
+#include "email/email/curl_sender.hpp"
 #include "email/email/info.hpp"
-#include "email/email/sender.hpp"
 #include "email/init.hpp"
 
 int main(int argc, char ** argv)
 {
   email::init(argc, argv);
   auto options = email::get_global_context()->get_options();
-  email::EmailSender sender(
+  email::CurlEmailSender sender(
     options->get_user_info(),
     options->get_recipients(),
     options->curl_verbose());


### PR DESCRIPTION
Part of #178

This splits the current `EmailSender` into a more abstract `EmailSender` class and a `CurlEmailSender`. Then we can have another kind of email sender, like an intraprocess email sender.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>