### PR TITLE
Create abstract EmailReceiver and extract CurlEmailReceiver

### DIFF
--- a/email/CMakeLists.txt
+++ b/email/CMakeLists.txt
@@ -53,6 +53,7 @@ set(SOURCES
   src/context.cpp
   src/curl/context.cpp
   src/curl/executor.cpp
+  src/email/curl_receiver.cpp
   src/email/curl_sender.cpp
   src/email/handler.cpp
   src/email/payload_utils.cpp

--- a/email/include/email/email/curl_receiver.hpp
+++ b/email/include/email/email/curl_receiver.hpp
@@ -1,0 +1,110 @@
+// Copyright 2020-2021 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EMAIL__EMAIL__CURL_RECEIVER_HPP_
+#define EMAIL__EMAIL__CURL_RECEIVER_HPP_
+
+#include <curl/curl.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
+#include <regex>
+#include <string>
+
+#include "email/curl/executor.hpp"
+#include "email/email/info.hpp"
+#include "email/email/receiver.hpp"
+#include "email/log.hpp"
+#include "email/macros.hpp"
+#include "email/visibility_control.hpp"
+
+namespace email
+{
+
+/// Email reception wrapper for curl.
+/**
+ * Sets the options and executes the commands to receive emails.
+ */
+class CurlEmailReceiver : public EmailReceiver, public CurlExecutor
+{
+public:
+  /// Constructor.
+  /**
+   * \param user_info the user information for receiving emails
+   * \param curl_verbose the curl verbose status
+   */
+  EMAIL_PUBLIC
+  explicit CurlEmailReceiver(
+    UserInfo::SharedPtrConst user_info,
+    const bool curl_verbose);
+
+  EMAIL_PUBLIC
+  virtual ~CurlEmailReceiver();
+
+  EMAIL_PUBLIC
+  virtual
+  std::optional<struct EmailData>
+  get_email(std::optional<std::chrono::nanoseconds> polling_period = std::nullopt);
+
+protected:
+  virtual
+  bool
+  init_options();
+
+private:
+  EMAIL_DISABLE_COPY(CurlEmailReceiver)
+
+  /// Get the NEXTUID value.
+  /**
+   * This value represents the predicted UID value of the next email, if there ever is a new email.
+   *
+   * \return the NEXTUID, or `std::nullopt` if it failed
+   */
+  std::optional<int>
+  get_nextuid();
+
+  /// Get an email from its UID.
+  /**
+   * Will fail if there is no email with that UID.
+   *
+   * \param uid the UID
+   * \return the email data, or `std::nullopt` if it failed
+   */
+  std::optional<struct EmailData>
+  get_email_from_uid(int uid);
+
+  /// Execute curl command.
+  /**
+   * \param url_options the options to append to the request URL, or `std::nullopt`
+   * \param custom_request the custom IMAP request, or `std::nullopt`
+   * \return the response, or `std::nullopt` if it failed
+   */
+  std::optional<std::string>
+  execute(std::optional<std::string> url_options, std::optional<std::string> custom_request);
+
+  /// Write callback for curl download/response reception.
+  static
+  size_t
+  write_callback(void * contents, size_t size, size_t nmemb, void * userp);
+
+  int current_uid_;
+  int next_uid_;
+  std::string read_buffer_;
+};
+
+}  // namespace email
+
+#endif  // EMAIL__EMAIL__CURL_RECEIVER_HPP_

--- a/email/include/email/email/curl_sender.hpp
+++ b/email/include/email/email/curl_sender.hpp
@@ -55,11 +55,6 @@ protected:
   bool
   init_options();
 
-  /// Send payload.
-  /**
-   * \param payload the payload
-   * \return true if successful, false otherwise
-   */
   virtual
   bool
   send_payload(const std::string & payload);

--- a/email/src/context.cpp
+++ b/email/src/context.cpp
@@ -17,8 +17,10 @@
 #include <string>
 
 #include "email/context.hpp"
+#include "email/email/curl_receiver.hpp"
 #include "email/email/curl_sender.hpp"
 #include "email/email/info.hpp"
+#include "email/email/receiver.hpp"
 #include "email/email/sender.hpp"
 #include "email/log.hpp"
 #include "email/utils.hpp"
@@ -108,10 +110,10 @@ Context::init_common()
   std::dynamic_pointer_cast<CurlEmailSender>(sender_)->init();
 
   assert(!receiver_);
-  receiver_ = std::make_shared<EmailReceiver>(
+  receiver_ = std::make_shared<CurlEmailReceiver>(
     options_->get_user_info(),
     options_->curl_verbose());
-  receiver_->init();
+  std::dynamic_pointer_cast<CurlEmailReceiver>(receiver_)->init();
 
   assert(!polling_manager_);
   polling_manager_ = std::make_shared<PollingManager>(receiver_, options_->polling_period());

--- a/email/src/email/curl_receiver.cpp
+++ b/email/src/email/curl_receiver.cpp
@@ -1,0 +1,175 @@
+// Copyright 2020-2021 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <curl/curl.h>
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <memory>
+#include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
+#include <regex>
+#include <string>
+#include <thread>
+
+#include "spdlog/fmt/bundled/chrono.h"
+
+#include "email/curl/executor.hpp"
+#include "email/email/curl_receiver.hpp"
+#include "email/email/info.hpp"
+#include "email/email/receiver.hpp"
+#include "email/email/response_utils.hpp"
+#include "email/log.hpp"
+
+namespace email
+{
+
+CurlEmailReceiver::CurlEmailReceiver(
+  UserInfo::SharedPtrConst user_info,
+  const bool curl_verbose)
+: EmailReceiver(user_info),
+  CurlExecutor(
+    {user_info->host_imap, user_info->username, user_info->password},
+    {"imaps", 993},
+    curl_verbose),
+  current_uid_(-1),
+  next_uid_(-1),
+  read_buffer_()
+{}
+
+CurlEmailReceiver::~CurlEmailReceiver()
+{
+  logger_->debug("destroying");
+}
+
+size_t
+CurlEmailReceiver::write_callback(void * contents, size_t size, size_t nmemb, void * userp)
+{
+  (static_cast<std::string *>(userp))->append(static_cast<char *>(contents), size * nmemb);
+  return size * nmemb;
+}
+
+bool
+CurlEmailReceiver::init_options()
+{
+  curl_easy_setopt(context_.get_handle(), CURLOPT_WRITEFUNCTION, write_callback);
+  curl_easy_setopt(context_.get_handle(), CURLOPT_WRITEDATA, static_cast<void *>(&read_buffer_));
+  return true;
+}
+
+std::optional<struct EmailData>
+CurlEmailReceiver::get_email(std::optional<std::chrono::nanoseconds> polling_period)
+{
+  if (!is_valid()) {
+    logger_->warn("not initialized!");
+    return std::nullopt;
+  }
+  std::chrono::nanoseconds period = polling_period.value_or(std::chrono::nanoseconds(0));
+  logger_->debug("polling: period={}", period);
+  // Update next UID
+  std::optional<int> next_uid = get_nextuid();
+  if (!next_uid) {
+    logger_->error("could not get next UID");
+    return std::nullopt;
+  }
+  next_uid_ = next_uid.value();
+  // Initalize current UID pointer if needed
+  if (0 > current_uid_) {
+    current_uid_ = next_uid_;
+  }
+  logger_->debug("current_uid={}", current_uid_);
+  logger_->debug("next_uid   ={}", next_uid_);
+  // Try until we get an email or until we have to stop
+  std::optional<struct EmailData> next_email = std::nullopt;
+  std::chrono::steady_clock::time_point last_poll;
+  while (!next_email && !do_shutdown_.load()) {
+    last_poll = std::chrono::steady_clock::now();
+    next_email = get_email_from_uid(current_uid_);
+    if (!do_shutdown_.load() && std::chrono::nanoseconds::zero() != period) {
+      std::this_thread::sleep_until(last_poll + period);
+    }
+  }
+  // Increment our current UID pointer, but only up to the previous 'next UID' value + 1.
+  // This allows us to not miss emails when there are multiple new ones.
+  // If we fetched the only new email (above), current UID will be equal to the initial next UID
+  // and so we increment the pointer to wait for the next one.
+  // If there was more than one new email, current UID will be lower than next UID and so we
+  // increment the pointer to get the next new email.
+  if (current_uid_ <= next_uid_) {
+    current_uid_++;
+  }
+  return next_email;
+}
+
+std::optional<struct EmailData>
+CurlEmailReceiver::get_email_from_uid(int uid)
+{
+  auto execute_result = execute("INBOX/;UID=" + std::to_string(uid), std::nullopt);
+  if (!execute_result) {
+    return std::nullopt;
+  }
+  return utils::response::get_email_data_from_response(execute_result.value());
+}
+
+std::optional<int>
+CurlEmailReceiver::get_nextuid()
+{
+  std::optional<std::string> response = execute(std::nullopt, "EXAMINE INBOX");
+  if (!response) {
+    return std::nullopt;
+  }
+  std::optional<int> next_uid = utils::response::get_nextuid_from_response(response.value());
+  return next_uid;
+}
+
+std::optional<std::string>
+CurlEmailReceiver::execute(
+  std::optional<std::string> url_options,
+  std::optional<std::string> custom_request)
+{
+  if (do_shutdown_.load()) {
+    return std::nullopt;
+  }
+
+  std::string request_url(context_.get_full_url());
+  if (url_options) {
+    request_url += url_options.value();
+  }
+  curl_easy_setopt(context_.get_handle(), CURLOPT_URL, request_url.c_str());
+  if (custom_request) {
+    curl_easy_setopt(context_.get_handle(), CURLOPT_CUSTOMREQUEST, custom_request.value().c_str());
+  } else {
+    // Unset the option in case it was set during a previous call
+    curl_easy_setopt(context_.get_handle(), CURLOPT_CUSTOMREQUEST, NULL);
+  }
+
+  logger_->debug(
+    "EXECUTE:\n"
+    "\turl    : {}\n"
+    "\tcommand: {}",
+    request_url,
+    (custom_request ? custom_request.value() : ""));
+
+  // Reset read buffer
+  read_buffer_.clear();
+
+  if (!context_.execute()) {
+    return std::nullopt;
+  }
+  logger_->debug("RESPONSE:\n{}", read_buffer_);
+  return read_buffer_;
+}
+
+}  // namespace email

--- a/email/src/email/receiver.cpp
+++ b/email/src/email/receiver.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Christophe Bedard
+// Copyright 2021 Christophe Bedard
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,170 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <curl/curl.h>
-
 #include <atomic>
-#include <cstdio>
-#include <cstring>
-#include <cstdlib>
 #include <memory>
 #include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
-#include <regex>
-#include <string>
-#include <thread>
 
-#include "spdlog/fmt/bundled/chrono.h"
-
-#include "email/curl/executor.hpp"
 #include "email/email/info.hpp"
 #include "email/email/receiver.hpp"
-#include "email/email/response_utils.hpp"
+// #include "email/email/response_utils.hpp"
 #include "email/log.hpp"
 
 namespace email
 {
 
-EmailReceiver::EmailReceiver(
-  UserInfo::SharedPtrConst user_info,
-  const bool curl_verbose)
-: CurlExecutor(
-    {user_info->host_imap, user_info->username, user_info->password},
-    {"imaps", 993},
-    curl_verbose),
-  logger_(log::create("EmailReceiver")),
-  current_uid_(-1),
-  next_uid_(-1),
-  read_buffer_(),
+EmailReceiver::EmailReceiver(UserInfo::SharedPtrConst user_info)
+: logger_(log::create("EmailReceiver")),
+  user_info_(user_info),
   do_shutdown_(false)
 {}
 
 EmailReceiver::~EmailReceiver()
 {
-  logger_->debug("destroying");
-}
-
-size_t
-EmailReceiver::write_callback(void * contents, size_t size, size_t nmemb, void * userp)
-{
-  (static_cast<std::string *>(userp))->append(static_cast<char *>(contents), size * nmemb);
-  return size * nmemb;
-}
-
-bool
-EmailReceiver::init_options()
-{
-  curl_easy_setopt(context_.get_handle(), CURLOPT_WRITEFUNCTION, write_callback);
-  curl_easy_setopt(context_.get_handle(), CURLOPT_WRITEDATA, static_cast<void *>(&read_buffer_));
-  return true;
+  // logger_->debug("destroying");
 }
 
 void
 EmailReceiver::shutdown()
 {
   do_shutdown_.store(true);
-}
-
-std::optional<struct EmailData>
-EmailReceiver::get_email(std::optional<std::chrono::nanoseconds> polling_period)
-{
-  if (!is_valid()) {
-    logger_->warn("not initialized!");
-    return std::nullopt;
-  }
-  std::chrono::nanoseconds period = polling_period.value_or(std::chrono::nanoseconds(0));
-  logger_->debug("polling: period={}", period);
-  // Update next UID
-  std::optional<int> next_uid = get_nextuid();
-  if (!next_uid) {
-    logger_->error("could not get next UID");
-    return std::nullopt;
-  }
-  next_uid_ = next_uid.value();
-  // Initalize current UID pointer if needed
-  if (0 > current_uid_) {
-    current_uid_ = next_uid_;
-  }
-  logger_->debug("current_uid={}", current_uid_);
-  logger_->debug("next_uid   ={}", next_uid_);
-  // Try until we get an email or until we have to stop
-  std::optional<struct EmailData> next_email = std::nullopt;
-  std::chrono::steady_clock::time_point last_poll;
-  while (!next_email && !do_shutdown_.load()) {
-    last_poll = std::chrono::steady_clock::now();
-    next_email = get_email_from_uid(current_uid_);
-    if (!do_shutdown_.load() && std::chrono::nanoseconds::zero() != period) {
-      std::this_thread::sleep_until(last_poll + period);
-    }
-  }
-  // Increment our current UID pointer, but only up to the previous 'next UID' value + 1.
-  // This allows us to not miss emails when there are multiple new ones.
-  // If we fetched the only new email (above), current UID will be equal to the initial next UID
-  // and so we increment the pointer to wait for the next one.
-  // If there was more than one new email, current UID will be lower than next UID and so we
-  // increment the pointer to get the next new email.
-  if (current_uid_ <= next_uid_) {
-    current_uid_++;
-  }
-  return next_email;
-}
-
-std::optional<struct EmailData>
-EmailReceiver::get_email_from_uid(int uid)
-{
-  auto execute_result = execute("INBOX/;UID=" + std::to_string(uid), std::nullopt);
-  if (!execute_result) {
-    return std::nullopt;
-  }
-  return utils::response::get_email_data_from_response(execute_result.value());
-}
-
-std::optional<int>
-EmailReceiver::get_nextuid()
-{
-  std::optional<std::string> response = execute(std::nullopt, "EXAMINE INBOX");
-  if (!response) {
-    return std::nullopt;
-  }
-  std::optional<int> next_uid = utils::response::get_nextuid_from_response(response.value());
-  return next_uid;
-}
-
-std::optional<std::string>
-EmailReceiver::execute(
-  std::optional<std::string> url_options,
-  std::optional<std::string> custom_request)
-{
-  if (do_shutdown_.load()) {
-    return std::nullopt;
-  }
-
-  std::string request_url(context_.get_full_url());
-  if (url_options) {
-    request_url += url_options.value();
-  }
-  curl_easy_setopt(context_.get_handle(), CURLOPT_URL, request_url.c_str());
-  if (custom_request) {
-    curl_easy_setopt(context_.get_handle(), CURLOPT_CUSTOMREQUEST, custom_request.value().c_str());
-  } else {
-    // Unset the option in case it was set during a previous call
-    curl_easy_setopt(context_.get_handle(), CURLOPT_CUSTOMREQUEST, NULL);
-  }
-
-  logger_->debug(
-    "EXECUTE:\n"
-    "\turl    : {}\n"
-    "\tcommand: {}",
-    request_url,
-    (custom_request ? custom_request.value() : ""));
-
-  // Reset read buffer
-  read_buffer_.clear();
-
-  if (!context_.execute()) {
-    return std::nullopt;
-  }
-  logger_->debug("RESPONSE:\n{}", read_buffer_);
-  return read_buffer_;
 }
 
 }  // namespace email

--- a/email_examples/src/receive.cpp
+++ b/email_examples/src/receive.cpp
@@ -18,15 +18,15 @@
 
 #include "email/context.hpp"
 #include "email/curl/info.hpp"
+#include "email/email/curl_receiver.hpp"
 #include "email/email/info.hpp"
-#include "email/email/receiver.hpp"
 #include "email/init.hpp"
 
 int main(int argc, char ** argv)
 {
   email::init(argc, argv);
   auto options = email::get_global_context()->get_options();
-  email::EmailReceiver receiver(options->get_user_info(), options->curl_verbose());
+  email::CurlEmailReceiver receiver(options->get_user_info(), options->curl_verbose());
   if (!receiver.init()) {
     return 1;
   }


### PR DESCRIPTION
Part of #178

Follow-up to #261

This splits the current `EmailReceiver` into a more abstract `EmailReceiver` class and a `CurlEmailReceiver`. Then we can have another kind of email receiver, like an intraprocess email receiver.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>