### PR TITLE
Remove trailing CRLF after email body

### DIFF
--- a/email/include/email/email/response_utils.hpp
+++ b/email/include/email/email/response_utils.hpp
@@ -54,11 +54,12 @@ get_email_headers_from_response(const std::string & response);
 /// Get email content from raw request response.
 /**
  * \param response the result of the request
+ * \param headers the headers already parsed from the response
  * \return the email content, or `std::nullopt` if it failed
  */
 EMAIL_PUBLIC
 std::optional<struct EmailContent>
-get_email_content_from_response(const std::string & response);
+get_email_content_from_response(const std::string & response, EmailHeaders & headers);
 
 /// Get raw email data from raw request response.
 /**

--- a/email/src/email/payload_utils.cpp
+++ b/email/src/email/payload_utils.cpp
@@ -52,11 +52,10 @@ build_payload(
   // seems to handle it correctly even if it contains "\n" instead of "\r\n" even
   // if RFC 5322 says that CR & LF characters should always go together as a pair,
   // so we do not try to replace lone LF characters in the body with CRLF sequences.
-  // TODO(christophebedard) remove the CRLF sequence after the body?
   return utils::string_format(
     "%s"
     "In-Reply-To: %s\r\nReferences: %s\r\n"
-    "To: %s\r\nCc: %s\r\nBcc: %s\r\nSubject: %s\r\n\r\n%s\r\n",
+    "To: %s\r\nCc: %s\r\nBcc: %s\r\nSubject: %s\r\n\r\n%s",
     additional_headers_stream.str().c_str(),
     (reply_ref.has_value() ? reply_ref.value().c_str() : ""),
     (reply_ref.has_value() ? reply_ref.value().c_str() : ""),

--- a/email/src/email/response_utils.cpp
+++ b/email/src/email/response_utils.cpp
@@ -35,13 +35,10 @@ static constexpr auto HEADER_IN_REPLY_TO = "In-Reply-To";
 static constexpr auto HEADER_MESSAGE_ID = "Message-ID";
 static constexpr auto HEADER_SUBJECT = "Subject";
 static constexpr auto HEADER_TO = "To";
-// Summary of RFC 5322:
+// From RFC 5322:
 // CR and LF always go together as a pair (CRLF), although here we make the CR character optional.
 // The body is separated from the headers by an empty line, so there are two (CR)LF sequences.
-// We assume that there is a (CR)LF sequence after the body that isn't part of the body;
-// any additional (CR)LF sequence is assumed to be part of the body itself.
-// TODO(christophebedard) remove the above requirement/assumption?
-static const std::regex REGEX_BODY(R"((?:\r?\n){2}((?:.*(?:\r?\n)?)*)(?:\r?\n))");
+static const std::regex REGEX_BODY(R"((?:\r?\n){2}((?:.*(?:\r?\n)?)*))");
 static const std::regex REGEX_HEADER(R"(([a-zA-Z\-]+): (.*)\r)");
 static const std::regex REGEX_NEXTUID(R"(OK \[UIDNEXT ([0-9]+)\] Predicted next UID)");
 

--- a/email/test/test_utils_payload.cpp
+++ b/email/test/test_utils_payload.cpp
@@ -47,7 +47,7 @@ TEST(TestPayloadUtils, build_payload) {
     "Cc: \r\n" \
     "Bcc: \r\n" \
     "Subject: this is my awesome subject\r\n\r\n" \
-    "this is the email's body\r\n";
+    "this is the email's body";
   email::EmailRecipients::SharedPtrConst recipients_one =
     std::make_shared<const struct email::EmailRecipients>("my@email.com");
   const struct email::EmailContent content_one_line = {
@@ -62,7 +62,7 @@ TEST(TestPayloadUtils, build_payload) {
     "Cc: onecc@email.ca\r\n" \
     "Bcc: first@email.ca, second@email.net, third@email.de\r\n" \
     "Subject: this is my awesome subject\r\n\r\n" \
-    "this is the email's body\r\n";
+    "this is the email's body";
   email::EmailRecipients::SharedPtrConst recipients_multiple =
     std::make_shared<const struct email::EmailRecipients>(
     std::vector<std::string>{"my@email.com", "another@email.com"},
@@ -82,7 +82,7 @@ TEST(TestPayloadUtils, build_payload) {
     "Cc: onecc@email.ca\r\n" \
     "Bcc: first@email.ca, second@email.net, third@email.de\r\n" \
     "Subject: this is my awesome subject that stops here\r\n\r\n" \
-    "this is the email's body\non multiple lines!\r\n";
+    "this is the email's body\non multiple lines!";
   EXPECT_EQ(
     payload_multiple_recipients_newlines,
     email::utils::payload::build_payload(recipients_multiple, content_multiple_lines));
@@ -94,7 +94,7 @@ TEST(TestPayloadUtils, build_payload) {
     "Cc: \r\n" \
     "Bcc: \r\n" \
     "Subject: this is my awesome subject\r\n\r\n" \
-    "this is the email's body\r\n";
+    "this is the email's body";
   const std::string reply_ref = "thisisaref";
   EXPECT_EQ(
     payload_reply_ref,
@@ -116,7 +116,7 @@ TEST(TestPayloadUtils, build_payload) {
     "Cc: \r\n" \
     "Bcc: \r\n" \
     "Subject: this is my awesome subject\r\n\r\n" \
-    "this is the email's body\r\n";
+    "this is the email's body";
   EXPECT_EQ(
     payload_additional_headers,
     email::utils::payload::build_payload(


### PR DESCRIPTION
This greatly simplifies parsing of the response string.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>