### PR TITLE
Improve coverage and simplify context destruction

### DIFF
--- a/email/include/email/context.hpp
+++ b/email/include/email/context.hpp
@@ -74,7 +74,7 @@ public:
 /// Context object with global resources.
 /**
  * It gets initialized only once.
- * It owns global objects which get created & initialized when needed.
+ * It owns global objects which get created & initialized.
  */
 class Context
 {
@@ -110,7 +110,8 @@ public:
 
   /// Shut down context.
   /**
-   * Shouldn't be called directly: use `email::shutdown()` instead.
+   * This should be called at the end before context destruction.
+   * However, it shouldn't be called directly: use `email::shutdown()` instead.
    *
    * \return true if successful, false otherwise
    */

--- a/email/include/email/init.hpp
+++ b/email/include/email/init.hpp
@@ -42,6 +42,8 @@ init(int argc, char const * const argv[]);
 
 /// Shut down context.
 /**
+ * This should be called at the end before exiting.
+ *
  * \return true if successful, false otherwise
  */
 EMAIL_PUBLIC

--- a/email/src/context.cpp
+++ b/email/src/context.cpp
@@ -57,9 +57,9 @@ Context::~Context()
   // Logger might not have been initialized
   if (logger_) {
     logger_->debug("destroying");
-  }
-  if (is_valid()) {
-    (void)shutdown();
+    if (is_valid()) {
+      logger_->error("context should have been shut down before destruction");
+    }
   }
 }
 
@@ -155,20 +155,15 @@ Context::shutdown()
   logger_->debug("shutting down");
 
   // Finalize in the reverse order
-  assert(service_handler_);
   service_handler_ = nullptr;
 
-  assert(subscription_handler_);
   subscription_handler_ = nullptr;
 
-  assert(polling_manager_);
   polling_manager_->shutdown();
   polling_manager_ = nullptr;
 
-  assert(sender_);
   sender_ = nullptr;
 
-  assert(receiver_);
   receiver_->shutdown();
   receiver_ = nullptr;
 

--- a/email/test/test_end_to_end.cpp
+++ b/email/test/test_end_to_end.cpp
@@ -175,19 +175,21 @@ TEST_F(TestEndToEnd, intraprocess_service) {
   email::SequenceNumber seq2 = client2.send_request("an awesome request");
   EXPECT_NE(seq1, seq2);
 
+  EXPECT_FALSE(client1.has_response(seq1));
+  EXPECT_FALSE(client2.has_response(seq2));
   EXPECT_FALSE(client1.get_response(seq1).has_value());
   EXPECT_FALSE(client2.get_response(seq2).has_value());
 
   email::WaitSet waitset;
   waitset.add_server(&server1);
   EXPECT_FALSE(waitset.wait());
+  ASSERT_TRUE(server1.has_request());
   waitset.clear();
   waitset.add_server(&server2);
   EXPECT_FALSE(waitset.wait());
+  ASSERT_TRUE(server2.has_request());
   waitset.clear();
 
-  ASSERT_TRUE(server1.has_request());
-  ASSERT_TRUE(server2.has_request());
   auto req_with_info_1_opt = server1.get_request_with_info();
   auto req_with_info_2_opt = server2.get_request_with_info();
   ASSERT_TRUE(req_with_info_1_opt.has_value());
@@ -224,13 +226,15 @@ TEST_F(TestEndToEnd, intraprocess_service) {
 
   waitset.add_client(&client1);
   EXPECT_FALSE(waitset.wait());
+  ASSERT_TRUE(client1.has_response());
+  ASSERT_TRUE(client1.has_response(seq1));
   waitset.clear();
   waitset.add_client(&client2);
   EXPECT_FALSE(waitset.wait());
+  ASSERT_TRUE(client2.has_response());
+  ASSERT_TRUE(client2.has_response(seq2));
   waitset.clear();
 
-  ASSERT_TRUE(client1.has_response());
-  ASSERT_TRUE(client2.has_response());
   auto res_with_info_1_opt = client1.get_response_with_info();
   auto res_with_info_2_opt = client2.get_response_with_info();
   ASSERT_TRUE(res_with_info_1_opt.has_value());


### PR DESCRIPTION
And make it clear that `email::shutdown()` must be called.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>