### PR TITLE
Exclude std::bind lines with LCOV_EXCL_LINE

### DIFF
--- a/email/src/service_handler.cpp
+++ b/email/src/service_handler.cpp
@@ -43,12 +43,14 @@ ServiceHandler::ServiceHandler()
   mutex_servers_(),
   servers_()
 {
+  // *INDENT-OFF* (uncrustify wants to put the lcov exclude comment on the next line)
   // Register handler with the polling manager
   get_global_context()->get_polling_manager()->register_handler(
-    std::bind(
+    std::bind(  // LCOV_EXCL_LINE (for some reason this is never marked as executed)
       &ServiceHandler::handle,
       this,
       std::placeholders::_1));
+  // *INDENT-ON*
   logger_->debug("initialized");
 }
 

--- a/email/src/subscription_handler.cpp
+++ b/email/src/subscription_handler.cpp
@@ -37,12 +37,14 @@ SubscriptionHandler::SubscriptionHandler()
   subscriptions_mutex_(),
   subscriptions_()
 {
+  // *INDENT-OFF* (uncrustify wants to put the lcov exclude comment on the next line)
   // Register handler with the polling manager
   get_global_context()->get_polling_manager()->register_handler(
-    std::bind(
+    std::bind(  // LCOV_EXCL_LINE (for some reason this is never marked as executed)
       &SubscriptionHandler::handle,
       this,
       std::placeholders::_1));
+  // *INDENT-ON*
   logger_->debug("initialized");
 }
 


### PR DESCRIPTION
The `std::bind` lines/calls themselves are apparently never hit/executed according to lcov, even if the statements before & after them are hit.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>