### PR TITLE
Decouple handlers from global context, test registration assert

### DIFF
--- a/email/CMakeLists.txt
+++ b/email/CMakeLists.txt
@@ -177,6 +177,10 @@ if(BUILD_TESTING)
     test/test_gid.cpp
   )
   target_link_libraries(test_gid ${PROJECT_NAME})
+  ament_add_gtest(test_handlers
+    test/test_handlers.cpp
+  )
+  target_link_libraries(test_handlers ${PROJECT_NAME})
   ament_add_gtest(test_log
     test/test_log.cpp
   )

--- a/email/include/email/email/handler.hpp
+++ b/email/include/email/email/handler.hpp
@@ -16,8 +16,10 @@
 #define EMAIL__EMAIL__HANDLER_HPP_
 
 #include <atomic>
+#include <memory>
 
 #include "email/email/info.hpp"
+#include "email/email/polling_manager.hpp"
 
 namespace email
 {
@@ -31,12 +33,14 @@ class EmailHandler
 public:
   /// Register this handler.
   /**
-   * Registers this handler so that it is called with new emails.
+   * Registers this handler with the `PollingManager` so that it is called with new emails.
    * To be called after creation.
+   *
+   * \param polling_manager the polling manager to register with
    */
   virtual
   void
-  register_handler() = 0;
+  register_handler(std::shared_ptr<PollingManager> polling_manager) = 0;
 
   /// Handle new email.
   /**

--- a/email/include/email/service_handler.hpp
+++ b/email/include/email/service_handler.hpp
@@ -25,6 +25,7 @@
 
 #include "email/email/handler.hpp"
 #include "email/email/info.hpp"
+#include "email/email/polling_manager.hpp"
 #include "email/gid.hpp"
 #include "email/log.hpp"
 #include "email/macros.hpp"
@@ -77,7 +78,7 @@ public:
 
   virtual
   void
-  register_handler();
+  register_handler(std::shared_ptr<PollingManager> polling_manager);
 
   /// Handle new email.
   /**

--- a/email/include/email/subscription_handler.hpp
+++ b/email/include/email/subscription_handler.hpp
@@ -24,6 +24,7 @@
 
 #include "email/email/handler.hpp"
 #include "email/email/info.hpp"
+#include "email/email/polling_manager.hpp"
 #include "email/safe_queue.hpp"
 #include "email/log.hpp"
 #include "email/macros.hpp"
@@ -62,7 +63,7 @@ public:
 
   virtual
   void
-  register_handler();
+  register_handler(std::shared_ptr<PollingManager> polling_manager);
 
   /// Handle new email.
   /**

--- a/email/src/context.cpp
+++ b/email/src/context.cpp
@@ -138,11 +138,11 @@ Context::init_common()
 
   assert(!subscription_handler_);
   subscription_handler_ = std::make_shared<SubscriptionHandler>();
-  subscription_handler_->register_handler();
+  subscription_handler_->register_handler(polling_manager_);
 
   assert(!service_handler_);
   service_handler_ = std::make_shared<ServiceHandler>();
-  service_handler_->register_handler();
+  service_handler_->register_handler(polling_manager_);
 
   logger_->debug("initialized");
 }

--- a/email/src/service_handler.cpp
+++ b/email/src/service_handler.cpp
@@ -18,7 +18,6 @@
 #include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
 #include <string>
 
-#include "email/context.hpp"
 #include "email/email/handler.hpp"
 #include "email/email/info.hpp"
 #include "email/email/polling_manager.hpp"
@@ -52,10 +51,10 @@ ServiceHandler::~ServiceHandler()
 }
 
 void
-ServiceHandler::register_handler()
+ServiceHandler::register_handler(std::shared_ptr<PollingManager> polling_manager)
 {
   // Register handler with the polling manager
-  get_global_context()->get_polling_manager()->register_handler(
+  polling_manager->register_handler(
     [handler = std::weak_ptr<ServiceHandler>(this->shared_from_this())](
       const struct EmailData & data) {
       if (auto handler_ptr = handler.lock()) {

--- a/email/src/subscription_handler.cpp
+++ b/email/src/subscription_handler.cpp
@@ -18,7 +18,6 @@
 #include <string>
 #include <utility>
 
-#include "email/context.hpp"
 #include "email/email/handler.hpp"
 #include "email/email/info.hpp"
 #include "email/email/polling_manager.hpp"
@@ -46,10 +45,10 @@ SubscriptionHandler::~SubscriptionHandler()
 }
 
 void
-SubscriptionHandler::register_handler()
+SubscriptionHandler::register_handler(std::shared_ptr<PollingManager> polling_manager)
 {
   // Register handler with the polling manager
-  get_global_context()->get_polling_manager()->register_handler(
+  polling_manager->register_handler(
     [handler = std::weak_ptr<SubscriptionHandler>(this->shared_from_this())](
       const struct EmailData & data) {
       if (auto handler_ptr = handler.lock()) {

--- a/email/test/test_handlers.cpp
+++ b/email/test/test_handlers.cpp
@@ -1,0 +1,43 @@
+// Copyright 2021 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "email/gid.hpp"
+#include "email/service_handler.hpp"
+#include "email/subscription_handler.hpp"
+
+TEST(TestHandlers, service_handler_fail)
+{
+  auto service_handler = std::make_shared<email::ServiceHandler>();
+
+  // Register service client & server without having registered the service handler itself
+  auto client_gid = email::Gid::new_gid();
+  auto client_response_map = std::make_shared<email::ServiceHandler::ResponseMap>();
+  EXPECT_DEATH(service_handler->register_service_client(client_gid, client_response_map), "");
+
+  auto server_request_queue = std::make_shared<email::ServiceHandler::RequestQueue>();
+  EXPECT_DEATH(service_handler->register_service_server("/my_service", server_request_queue), "");
+}
+
+TEST(TestHandlers, subscription_handler_fail)
+{
+  auto subscription_handler = std::make_shared<email::SubscriptionHandler>();
+
+  // Register subscription without having registered the subscription handler itself
+  auto message_queue = std::make_shared<email::SubscriptionHandler::MessageQueue>();
+  EXPECT_DEATH(subscription_handler->register_subscription("/my_topic", message_queue), "");
+}


### PR DESCRIPTION
This decouples the `ServiceHandler` and `SubscriptionHandler` from the global context, since they're created by the context itself.

I also added tests to check the registration assertions.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>