### PR TITLE
Use weak_ptrs in {Sub,Srv}Handler and remove if not lockable

### DIFF
--- a/email/include/email/macros.hpp
+++ b/email/include/email/macros.hpp
@@ -35,4 +35,10 @@
 #define EMAIL_SHARED_PTR(...) \
   using SharedPtr = std::shared_ptr<__VA_ARGS__>;
 
+/**
+ * Declare std::weak_ptr<T>.
+ */
+#define EMAIL_WEAK_PTR(...) \
+  using WeakPtr = std::weak_ptr<__VA_ARGS__>;
+
 #endif  // EMAIL__MACROS_HPP_

--- a/email/include/email/safe_map.hpp
+++ b/email/include/email/safe_map.hpp
@@ -41,6 +41,7 @@ public:
     map_()
   {}
   EMAIL_SHARED_PTR(SafeMap)
+  EMAIL_WEAK_PTR(SafeMap)
 
   ~SafeMap() {}
 

--- a/email/include/email/safe_queue.hpp
+++ b/email/include/email/safe_queue.hpp
@@ -40,6 +40,7 @@ public:
     queue_()
   {}
   EMAIL_SHARED_PTR(SafeQueue)
+  EMAIL_WEAK_PTR(SafeQueue)
 
   ~SafeQueue() {}
 

--- a/email/include/email/service_handler.hpp
+++ b/email/include/email/service_handler.hpp
@@ -64,7 +64,7 @@ public:
   void
   register_service_client(
     const Gid & gid,
-    ResponseMap::SharedPtr response_map);
+    ResponseMap::WeakPtr response_map);
 
   /// Register a service server with the handler.
   /**
@@ -74,7 +74,7 @@ public:
   void
   register_service_server(
     const std::string & service_name,
-    RequestQueue::SharedPtr request_queue);
+    RequestQueue::WeakPtr request_queue);
 
   virtual
   void
@@ -100,10 +100,10 @@ private:
 
   std::shared_ptr<Logger> logger_;
   mutable std::mutex mutex_clients_;
-  std::unordered_map<GidValue, ResponseMap::SharedPtr> clients_;
+  std::unordered_map<GidValue, ResponseMap::WeakPtr> clients_;
   std::unordered_map<GidValue, SequenceNumber> clients_last_seq_;
   mutable std::mutex mutex_servers_;
-  std::unordered_multimap<std::string, RequestQueue::SharedPtr> servers_;
+  std::unordered_multimap<std::string, RequestQueue::WeakPtr> servers_;
 };
 
 }  // namespace email

--- a/email/include/email/subscription_handler.hpp
+++ b/email/include/email/subscription_handler.hpp
@@ -59,7 +59,7 @@ public:
   void
   register_subscription(
     const std::string & topic_name,
-    MessageQueue::SharedPtr message_queue);
+    MessageQueue::WeakPtr message_queue);
 
   virtual
   void
@@ -78,7 +78,7 @@ private:
 
   std::shared_ptr<Logger> logger_;
   mutable std::mutex subscriptions_mutex_;
-  std::unordered_multimap<std::string, MessageQueue::SharedPtr> subscriptions_;
+  std::unordered_multimap<std::string, MessageQueue::WeakPtr> subscriptions_;
 };
 
 }  // namespace email


### PR DESCRIPTION
Closes #174

This makes the `SubscriptionHandler` and `ServiceHandler` use `std::weak_ptr`s to subscription/client/server queues/maps instead of `std::shared_ptr`s. This makes ownership clear: the handlers don't own them. If the corresponding `std::weak_ptr` can't be locked (if a subscription/client/server is destroyed), it is removed/unregistered from the handler. This makes more sense than unregistering it (i.e., calling a function to remove it from a handler) on destruction.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>