### PR TITLE
Replace main codecov badge with per-package coverage badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Latest GitHub tag](https://img.shields.io/github/v/tag/christophebedard/rmw_email?sort=semver&label=v)](https://github.com/christophebedard/rmw_email/tags)
 [![GitHub workflow status](https://github.com/christophebedard/rmw_email/workflows/Test/badge.svg)](https://github.com/christophebedard/rmw_email/actions)
-[![codecov](https://codecov.io/gh/christophebedard/rmw_email/branch/master/graph/badge.svg?token=20FSAUKMDB)](https://codecov.io/gh/christophebedard/rmw_email)
 [![License](https://img.shields.io/github/license/christophebedard/rmw_email)](https://github.com/christophebedard/rmw_email/blob/master/LICENSE)
 
 ROS 2 over email.
@@ -50,6 +49,7 @@ Service responses are email replies to the corresponding email request (this is 
 This repository contains a few packages:
 
 * [`email`](./email/): simple publish/subscribe & service middleware using emails to exchange strings
+   * ![](https://img.shields.io/badge/coverage%3A%20email-%3E%2094%25-brightgreen)
    * See the [API documentation](https://christophebedard.com/rmw_email/api/email/).
    * See the [design document](./email/doc/design.md) ([rendered version](https://christophebedard.com/rmw_email/design/email/)).
    * This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./email/QUALITY_DECLARATION.md) for more details.
@@ -57,6 +57,7 @@ This repository contains a few packages:
    * See [*`email` examples*](#email-examples).
    * This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./email_examples/QUALITY_DECLARATION.md) for more details.
 * [`rmw_email_cpp`](./rmw_email_cpp/): ROS 2 `rmw` implementation using `email` as the middleware
+   * ![](https://img.shields.io/badge/coverage%3A%20rmw__email__cpp-%3E%2060%25-orange)
    * See [*supported features*](#supported-features).
    * This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./rmw_email_cpp/QUALITY_DECLARATION.md) for more details.
 


### PR DESCRIPTION
The codecov coverage result is far below what I get when running tests locally.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>