### PR TITLE
Update rcpputils/env.hpp header #include

### DIFF
--- a/email/src/utils.cpp
+++ b/email/src/utils.cpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-#include "rcpputils/get_env.hpp"
+#include "rcpputils/env.hpp"
 #include "rcpputils/split.hpp"
 
 #include "email/utils.hpp"


### PR DESCRIPTION
`rcpputils/get_env.hpp` is deprecated.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>