### PR TITLE
Change default branch to rolling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - rolling
 jobs:
   test:
     name: "Build and test"
@@ -29,7 +29,7 @@ jobs:
         target-ros2-distro: rolling
         vcs-repo-file-url: |
           ${{ github.workspace }}/dependencies.repos
-          ${{ matrix.build-type == 'source' && 'https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos' || '' }}
+          ${{ matrix.build-type == 'source' && 'https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos' || '' }}
         import-token: ${{ secrets.GITHUB_TOKEN }}
         colcon-defaults: |
           {

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - rolling
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,7 +2,7 @@ name: Documentation
 on:
   push:
     branches:
-      - master
+      - rolling
 jobs:
   docs_gen:
     name: "Generate and push"
@@ -36,21 +36,21 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v2
       with:
-        ref: master
+        ref: rolling
         fetch-depth: 0
-        path: repos/master/
+        path: repos/rolling/
     - name: Gen API docs
       run: |
         python3 gen_docs/gen_docs.py --config gh-pages/gen_docs.yml --skip-clone
     - name: Gen design docs
       run: |
         mkdir -p pandoc/email/ && cd pandoc/email/
-        sed -i '/christophebedard.com/d' ../../repos/master/email/doc/design.md
-        pandoc ../../repos/master/email/doc/design.md --filter pandoc-plantuml > index.html
+        sed -i '/christophebedard.com/d' ../../repos/rolling/email/doc/design.md
+        pandoc ../../repos/rolling/email/doc/design.md --filter pandoc-plantuml > index.html
     - name: Copy docs to gh-pages
       run: |
         rm -rf gh-pages/api/
-        mv -T output/master/ gh-pages/api/
+        mv -T output/rolling/ gh-pages/api/
         rm -rf gh-pages/design/
         mv -T pandoc/ gh-pages/design/
     - name: Commit and push to gh-pages branch

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -2,7 +2,7 @@ name: Tag
 on:
   push:
     branches:
-      - master
+      - rolling
 jobs:
   tag:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest GitHub tag](https://img.shields.io/github/v/tag/christophebedard/rmw_email?sort=semver&label=version)](https://github.com/christophebedard/rmw_email/tags)
 [![GitHub workflow status](https://github.com/christophebedard/rmw_email/workflows/Test/badge.svg)](https://github.com/christophebedard/rmw_email/actions)
-[![License](https://img.shields.io/github/license/christophebedard/rmw_email)](https://github.com/christophebedard/rmw_email/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/christophebedard/rmw_email)](https://github.com/christophebedard/rmw_email/blob/rolling/LICENSE)
 
 ROS 2 over email.
 rmw_email contains a middleware that sends & receives strings over email and an RMW implementation that allows ROS 2 to use this middleware to exchange messages.
@@ -103,7 +103,7 @@ See the [`perf_test.sh`](./rmw_email_cpp/perf/perf_test.sh) and [`perf_plot.sh`]
 1. Clone dependencies
    ```sh
    $ cd ~/ws/
-   $ vcs import src --input https://raw.githubusercontent.com/christophebedard/rmw_email/master/dependencies.repos
+   $ vcs import src --input https://raw.githubusercontent.com/christophebedard/rmw_email/rolling/dependencies.repos
    ```
 1. Build
    ```sh
@@ -165,10 +165,10 @@ See [`email/include/email/lttng.hpp`](./email/include/email/lttng.hpp).
 Tracepoints are automatically included if LTTng is installed and detected.
 To completely remove them, build with `--cmake-args -DEMAIL_ENABLE_TRACING=OFF`.
 
-`rmw_email_cpp` supports the [`ros2_tracing`](https://gitlab.com/ros-tracing/ros2_tracing) tracepoints for the `rmw` layer.
+`rmw_email_cpp` supports the [`ros2_tracing`](https://github.com/ros2/ros2_tracing) tracepoints for the `rmw` layer.
 It also has another LTTng tracepoint in order to link ROS 2 messages to `email` messages.
 See [`rmw_email_cpp/include/rmw_email_cpp/lttng.hpp`](./rmw_email_cpp/include/rmw_email_cpp/lttng.hpp).
-See [`ros2_tracing`'s README](https://gitlab.com/ros-tracing/ros2_tracing#building) for information on how to enable or disable tracepoints.
+See [`ros2_tracing`'s README](https://github.com/ros2/ros2_tracing#building) for information on how to enable or disable tracepoints.
 
 ## Logging
 

--- a/email/Doxyfile
+++ b/email/Doxyfile
@@ -1,7 +1,7 @@
 # All settings not listed here will use the Doxygen default values.
 
 PROJECT_NAME           = "email"
-PROJECT_NUMBER         = master
+PROJECT_NUMBER         = rolling
 PROJECT_BRIEF          = "Email-based middleware"
 
 INPUT                  = ./include

--- a/email/QUALITY_DECLARATION.md
+++ b/email/QUALITY_DECLARATION.md
@@ -84,14 +84,14 @@ There is documentation for all of the features, and new features require documen
 
 The license for `email` is Apache 2.0, and a summary is in each source file, the type is declared in the [`package.xml`](./package.xml) manifest file, and a full copy of the license is in the [`LICENSE`](../LICENSE) file.
 
-There is an automated test using [`ament_copyright`](https://github.com/ament/ament_lint/tree/master/ament_copyright) through `ament_lint_common` that ensures each file has a license statement.
+There is an automated test using [`ament_copyright`](https://github.com/ament/ament_lint/tree/rolling/ament_copyright) through `ament_lint_common` that ensures each file has a license statement.
 
 ### Copyright Statements [3.iv]
 <!-- yes -->
 
 The copyright holders each provide a statement of copyright in each source code file in `email`.
 
-There is an automated test using [`ament_copyright`](https://github.com/ament/ament_lint/tree/master/ament_copyright) through `ament_lint_common` that ensures each file has a license statement.
+There is an automated test using [`ament_copyright`](https://github.com/ament/ament_lint/tree/rolling/ament_copyright) through `ament_lint_common` that ensures each file has a license statement.
 
 ## Testing [4]
 
@@ -154,13 +154,13 @@ It also has several test dependencies, which do not affect the resulting quality
 
 The `rcpputils` package provides an API which contains common utilities and data structures useful when programming in C++.
 
-It is **Quality Level 1**, see its [Quality Declaration document](https://github.com/ros2/rcpputils/blob/master/QUALITY_DECLARATION.md).
+It is **Quality Level 1**, see its [Quality Declaration document](https://github.com/ros2/rcpputils/blob/rolling/QUALITY_DECLARATION.md).
 
 #### `rcutils`
 
 The `rcutils` package provides an API which contains common utilities and data structures useful when programming in C.
 
-It is **Quality Level 1**, see its [Quality Declaration document](https://github.com/ros2/rcutils/blob/master/QUALITY_DECLARATION.md).
+It is **Quality Level 1**, see its [Quality Declaration document](https://github.com/ros2/rcutils/blob/rolling/QUALITY_DECLARATION.md).
 
 ### Direct Runtime non-ROS Dependency [5.iii]
 <!-- no -->

--- a/email_examples/QUALITY_DECLARATION.md
+++ b/email_examples/QUALITY_DECLARATION.md
@@ -84,14 +84,14 @@ There is however [a list of the examples it provides](../README.md#email-example
 
 The license for `email_examples` is Apache 2.0, and a summary is in each source file, the type is declared in the [`package.xml`](./package.xml) manifest file, and a full copy of the license is in the [`LICENSE`](../LICENSE) file.
 
-There is an automated test using [`ament_copyright`](https://github.com/ament/ament_lint/tree/master/ament_copyright) through `ament_lint_common` that ensures each file has a license statement.
+There is an automated test using [`ament_copyright`](https://github.com/ament/ament_lint/tree/rolling/ament_copyright) through `ament_lint_common` that ensures each file has a license statement.
 
 ### Copyright Statements [3.iv]
 <!-- yes -->
 
 The copyright holders each provide a statement of copyright in each source code file in `email_examples`.
 
-There is an automated test using [`ament_copyright`](https://github.com/ament/ament_lint/tree/master/ament_copyright) through `ament_lint_common` that ensures each file has a license statement.
+There is an automated test using [`ament_copyright`](https://github.com/ament/ament_lint/tree/rolling/ament_copyright) through `ament_lint_common` that ensures each file has a license statement.
 
 ## Testing [4]
 

--- a/rmw_email_cpp/QUALITY_DECLARATION.md
+++ b/rmw_email_cpp/QUALITY_DECLARATION.md
@@ -22,17 +22,17 @@ The current version can be found in its [package.xml](package.xml), and its chan
 ### Public API Declaration [1.iii]
 <!-- yes -->
 
-`rmw_email_cpp`'s public API is [`rmw`'s public API](https://github.com/ros2/rmw/blob/master/rmw/QUALITY_DECLARATION.md#public-api-declaration-1iii).
+`rmw_email_cpp`'s public API is [`rmw`'s public API](https://github.com/ros2/rmw/blob/rolling/rmw/QUALITY_DECLARATION.md#public-api-declaration-1iii).
 
 ### API Stability Within a Released ROS Distribution [1.iv]/[1.vi]
 <!-- yes -->
 
-`rmw_email_cpp` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released, as per [`rmw`'s Quality Declaration](https://github.com/ros2/rmw/blob/master/rmw/QUALITY_DECLARATION.md#api-stability-within-a-released-ros-distribution-1iv1vi).
+`rmw_email_cpp` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released, as per [`rmw`'s Quality Declaration](https://github.com/ros2/rmw/blob/rolling/rmw/QUALITY_DECLARATION.md#api-stability-within-a-released-ros-distribution-1iv1vi).
 
 ### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
 <!-- yes -->
 
-`rmw_email_cpp` will maintain ABI stability within a ROS distribution, as per [`rmw`'s Quality Declaration](https://github.com/ros2/rmw/blob/master/rmw/QUALITY_DECLARATION.md#abi-stability-within-a-released-ros-distribution-1v1vi).
+`rmw_email_cpp` will maintain ABI stability within a ROS distribution, as per [`rmw`'s Quality Declaration](https://github.com/ros2/rmw/blob/rolling/rmw/QUALITY_DECLARATION.md#abi-stability-within-a-released-ros-distribution-1v1vi).
 
 ## Change Control Process [2]
 
@@ -71,34 +71,34 @@ All pull requests must resolve related documentation changes before merging.
 ### Feature Documentation [3.i]
 <!-- yes -->
 
-`rmw_email_cpp`'s feature list is based on [`rmw`'s feature list](https://github.com/ros2/rmw/blob/master/rmw/QUALITY_DECLARATION.md#feature-documentation-3i).
+`rmw_email_cpp`'s feature list is based on [`rmw`'s feature list](https://github.com/ros2/rmw/blob/rolling/rmw/QUALITY_DECLARATION.md#feature-documentation-3i).
 Some of `rmw` features are currently not supported and are [documented in this repository's README](../README.md#supported-features).
 
 ### Public API Documentation [3.ii]
 <!-- yes -->
 
-`rmw_email_cpp`'s API is based on [`rmw`'s API](https://github.com/ros2/rmw/blob/master/rmw/QUALITY_DECLARATION.md#public-api-documentation-3ii).
+`rmw_email_cpp`'s API is based on [`rmw`'s API](https://github.com/ros2/rmw/blob/rolling/rmw/QUALITY_DECLARATION.md#public-api-documentation-3ii).
 
 ### License [3.iii]
 <!-- yes -->
 
 The license for `rmw_email_cpp` is Apache 2.0, and a summary is in each source file, the type is declared in the [`package.xml`](./package.xml) manifest file, and a full copy of the license is in the [`LICENSE`](../LICENSE) file.
 
-There is an automated test using [`ament_copyright`](https://github.com/ament/ament_lint/tree/master/ament_copyright) through `ament_lint_common` that ensures each file has a license statement.
+There is an automated test using [`ament_copyright`](https://github.com/ament/ament_lint/tree/rolling/ament_copyright) through `ament_lint_common` that ensures each file has a license statement.
 
 ### Copyright Statements [3.iv]
 <!-- yes -->
 
 The copyright holders each provide a statement of copyright in each source code file in `rmw_email_cpp`.
 
-There is an automated test using [`ament_copyright`](https://github.com/ament/ament_lint/tree/master/ament_copyright) through `ament_lint_common` that ensures each file has a license statement.
+There is an automated test using [`ament_copyright`](https://github.com/ament/ament_lint/tree/rolling/ament_copyright) through `ament_lint_common` that ensures each file has a license statement.
 
 ## Testing [4]
 
 ### Feature Testing [4.i]
 <!-- no -->
 
-All features in `rmw_email_cpp` have tests through [`rmw_implementation`](https://github.com/ros2/rmw_implementation/tree/master/rmw_implementation/test) and [`test_rmw_implementation`](https://github.com/ros2/rmw_implementation/tree/master/test_rmw_implementation/test) which simulate typical usage.
+All features in `rmw_email_cpp` have tests through [`rmw_implementation`](https://github.com/ros2/rmw_implementation/tree/rolling/rmw_implementation/test) and [`test_rmw_implementation`](https://github.com/ros2/rmw_implementation/tree/rolling/test_rmw_implementation/test) which simulate typical usage.
 Some other feature-related unit tests are located in the [`test`](./test) directory.
 
 Not all of those tests currently pass.
@@ -106,7 +106,7 @@ Not all of those tests currently pass.
 ### Public API Testing [4.ii]
 <!-- no -->
 
-All parts of the public API have tests through [`rmw_implementation`](https://github.com/ros2/rmw_implementation/tree/master/rmw_implementation/test) and [`test_rmw_implementation`](https://github.com/ros2/rmw_implementation/tree/master/test_rmw_implementation/test).
+All parts of the public API have tests through [`rmw_implementation`](https://github.com/ros2/rmw_implementation/tree/rolling/rmw_implementation/test) and [`test_rmw_implementation`](https://github.com/ros2/rmw_implementation/tree/rolling/test_rmw_implementation/test).
 The tests aim to cover both typical usage and corner cases, but are quantified by contributing to code coverage.
 
 Not all of those tests currently pass.
@@ -163,31 +163,31 @@ It currently has no quality declaration.
 
 The `rcpputils` package provides an API which contains common utilities and data structures useful when programming in C++.
 
-It is **Quality Level 1**, see its [Quality Declaration document](https://github.com/ros2/rcpputils/blob/master/QUALITY_DECLARATION.md).
+It is **Quality Level 1**, see its [Quality Declaration document](https://github.com/ros2/rcpputils/blob/rolling/QUALITY_DECLARATION.md).
 
 #### `rcutils`
 
 The `rcutils` package provides an API which contains common utilities and data structures useful when programming in C.
 
-It is **Quality Level 1**, see its [Quality Declaration document](https://github.com/ros2/rcutils/blob/master/QUALITY_DECLARATION.md).
+It is **Quality Level 1**, see its [Quality Declaration document](https://github.com/ros2/rcutils/blob/rolling/QUALITY_DECLARATION.md).
 
 #### `rmw`
 
 The `rmw` package is itself the ROS middleware API.
 
-It is **Quality Level 1**, see its [Quality Declaration document](https://github.com/ros2/rmw/blob/master/rmw/QUALITY_DECLARATION.md).
+It is **Quality Level 1**, see its [Quality Declaration document](https://github.com/ros2/rmw/blob/rolling/rmw/QUALITY_DECLARATION.md).
 
 #### `rosidl_runtime_c`
 
 The `rosidl_runtime_c` package provides definitions, initialization and finalization functions, and macros for getting and working with rosidl typesupport types in C.
 
-It is **Quality Level 1**, see its [Quality Declaration document](https://github.com/ros2/rosidl/blob/master/rosidl_runtime_c/QUALITY_DECLARATION.md).
+It is **Quality Level 1**, see its [Quality Declaration document](https://github.com/ros2/rosidl/blob/rolling/rosidl_runtime_c/QUALITY_DECLARATION.md).
 
 #### `rosidl_runtime_cpp`
 
 The `rosidl_runtime_cpp` package provides definitions and templated functions for getting and working with rosidl typesupport types in C++.
 
-It is **Quality Level 1**, see its [Quality Declaration document](https://github.com/ros2/rosidl/blob/master/rosidl_runtime_cpp/QUALITY_DECLARATION.md).
+It is **Quality Level 1**, see its [Quality Declaration document](https://github.com/ros2/rosidl/blob/rolling/rosidl_runtime_cpp/QUALITY_DECLARATION.md).
 
 #### `rosidl_typesupport_introspection_c`
 
@@ -205,7 +205,7 @@ It currently has no quality declaration.
 
 The `tracetools` package provides an API and tools to support instrumenting ROS packages, including core packages.
 
-It is **Quality Level 1**, see its [Quality Declaration document](https://gitlab.com/ros-tracing/ros2_tracing/-/blob/master/tracetools/QUALITY_DECLARATION.md).
+It is **Quality Level 1**, see its [Quality Declaration document](https://github.com/ros2/ros2_tracing/blob/rolling/tracetools/QUALITY_DECLARATION.md).
 
 ### Direct Runtime non-ROS Dependency [5.iii]
 <!-- yes -->

--- a/rmw_email_cpp/perf/perf_test.sh
+++ b/rmw_email_cpp/perf/perf_test.sh
@@ -31,8 +31,8 @@
 # Workspace setup:
 #   $ mkdir -p ws/src
 #   $ cd ws
-#   $ vcs import src --input https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
-#   $ vcs import src --input https://raw.githubusercontent.com/christophebedard/rmw_email/master/dependencies.repos
+#   $ vcs import src --input https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos
+#   $ vcs import src --input https://raw.githubusercontent.com/christophebedard/rmw_email/rolling/dependencies.repos
 #   $ cd src
 #   $ git clone https://github.com/christophebedard/rmw_email.git
 #   $ git clone https://gitlab.com/ApexAI/performance_test.git


### PR DESCRIPTION
And also:

* Update links to ROS 2 repos
* Update link to `ros2_tracing` repository (from GitLab to GitHub)

The issue with `colcon lcov-result` is unrelated and will be fixed in a later PR.