### PR TITLE
Update spdlog bundled #includes

### DIFF
--- a/email/include/email/email/info.hpp
+++ b/email/include/email/email/info.hpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-#include "spdlog/fmt/bundled/format.h"
+#include "spdlog/fmt/fmt.h"
 
 #include "email/macros.hpp"
 

--- a/email/src/email/curl_receiver.cpp
+++ b/email/src/email/curl_receiver.cpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <thread>
 
-#include "spdlog/fmt/bundled/chrono.h"
+#include "spdlog/fmt/chrono.h"
 
 #include "email/curl/executor.hpp"
 #include "email/email/curl_receiver.hpp"

--- a/email/src/email/polling_manager.cpp
+++ b/email/src/email/polling_manager.cpp
@@ -21,7 +21,7 @@
 #include <thread>
 #include <vector>
 
-#include "spdlog/fmt/bundled/chrono.h"
+#include "spdlog/fmt/chrono.h"
 
 #include "email/email/info.hpp"
 #include "email/email/polling_manager.hpp"


### PR DESCRIPTION
We're actually using `fmt` through `spdlog` here. We should probably include and depend on `fmt` directly, but this works.

There is another build error, but it's unrelated to this, so it will be fixed separately.