### PR TITLE
Expect rmw_request_id_t.writer_guid to be unsigned now

### DIFF
--- a/rmw_email_cpp/include/rmw_email_cpp/gid.hpp
+++ b/rmw_email_cpp/include/rmw_email_cpp/gid.hpp
@@ -27,10 +27,10 @@ namespace rmw_email_cpp
 rmw_gid_t convert_gid(const email::Gid & gid);
 
 /// Copy an email GID to a writer GUID.
-void copy_email_gid_to_writer_guid(int8_t * writer_guid, const email::Gid & gid);
+void copy_email_gid_to_writer_guid(uint8_t * writer_guid, const email::Gid & gid);
 
 /// Convert a writer GUID to an email GID.
-email::Gid convert_writer_guid_to_email_gid(int8_t * writer_guid);
+email::Gid convert_writer_guid_to_email_gid(uint8_t * writer_guid);
 
 /// Copy rmw GIDs.
 void copy_gids(rmw_gid_t * dest, rmw_gid_t * src);

--- a/rmw_email_cpp/src/gid.cpp
+++ b/rmw_email_cpp/src/gid.cpp
@@ -35,7 +35,7 @@ rmw_gid_t convert_gid(const email::Gid & gid)
   return rmw_gid;
 }
 
-void copy_email_gid_to_writer_guid(int8_t * writer_guid, const email::Gid & gid)
+void copy_email_gid_to_writer_guid(uint8_t * writer_guid, const email::Gid & gid)
 {
   const email::GidValue gid_value = gid.value();
   static_assert(
@@ -44,7 +44,7 @@ void copy_email_gid_to_writer_guid(int8_t * writer_guid, const email::Gid & gid)
   memcpy(writer_guid, &gid_value, sizeof(gid_value));
 }
 
-email::Gid convert_writer_guid_to_email_gid(int8_t * writer_guid)
+email::Gid convert_writer_guid_to_email_gid(uint8_t * writer_guid)
 {
   email::GidValue gid_value = 0u;
   static_assert(


### PR DESCRIPTION
Fixes #320

The test failure is unrelated and will be fixed separately.