### PR TITLE
Use structured bindings

### DIFF
--- a/email/src/service_client.cpp
+++ b/email/src/service_client.cpp
@@ -97,8 +97,7 @@ ServiceClient::get_response_with_info(const SequenceNumber sequence_number)
   if (it == responses_->cend()) {
     return std::nullopt;
   }
-  const auto email_data = it->second.first;
-  const auto info = it->second.second;
+  const auto [email_data, info] = it->second;
   const std::string response = email_data.content.body;
   responses_->erase(it);
   return {{response, info}};
@@ -112,8 +111,7 @@ ServiceClient::get_response_with_info()
   if (it == responses_->end()) {
     return std::nullopt;
   }
-  const auto email_data = it->second.first;
-  const auto info = it->second.second;
+  const auto [email_data, info] = it->second;
   const std::string response = email_data.content.body;
   responses_->erase(it);
   return {{response, info}};

--- a/email/src/service_server.cpp
+++ b/email/src/service_server.cpp
@@ -73,9 +73,7 @@ ServiceServer::get_request_with_info()
   if (!has_request()) {
     return std::nullopt;
   }
-  const auto request = requests_->dequeue();
-  const auto email_data = request.first;
-  const auto info = request.second;
+  const auto [email_data, info] = requests_->dequeue();
   // Put raw request data in a map so that we can
   // fetch & use it when sending our response
   requests_raw_.insert({info.sequence_number(), email_data});

--- a/email/test/test_end_to_end.cpp
+++ b/email/test/test_end_to_end.cpp
@@ -120,12 +120,8 @@ TEST_F(TestEndToEnd, intraprocess_pub_sub)
   auto msg_with_info_2_opt = sub2.get_message_with_info();
   ASSERT_TRUE(msg_with_info_1_opt.has_value());
   ASSERT_TRUE(msg_with_info_2_opt.has_value());
-  auto msg_with_info_1 = msg_with_info_1_opt.value();
-  auto msg_with_info_2 = msg_with_info_2_opt.value();
-  auto msg_1 = msg_with_info_1.first;
-  auto msg_2 = msg_with_info_2.first;
-  auto info_1 = msg_with_info_1.second;
-  auto info_2 = msg_with_info_2.second;
+  auto [msg_1, info_1] = msg_with_info_1_opt.value();
+  auto [msg_2, info_2] = msg_with_info_2_opt.value();
 
   EXPECT_STREQ(msg_1.c_str(), "some message");
   EXPECT_STREQ(msg_2.c_str(), "some other message");
@@ -200,12 +196,8 @@ TEST_F(TestEndToEnd, intraprocess_service)
   auto req_with_info_2_opt = server2.get_request_with_info();
   ASSERT_TRUE(req_with_info_1_opt.has_value());
   ASSERT_TRUE(req_with_info_2_opt.has_value());
-  auto req_with_info_1 = req_with_info_1_opt.value();
-  auto req_with_info_2 = req_with_info_2_opt.value();
-  auto req_1 = req_with_info_1.first;
-  auto req_2 = req_with_info_2.first;
-  auto req_info_1 = req_with_info_1.second;
-  auto req_info_2 = req_with_info_2.second;
+  auto [req_1, req_info_1] = req_with_info_1_opt.value();
+  auto [req_2, req_info_2] = req_with_info_2_opt.value();
 
   EXPECT_STREQ(req_1.content.c_str(), "a super request");
   EXPECT_STREQ(req_2.content.c_str(), "an awesome request");
@@ -245,12 +237,8 @@ TEST_F(TestEndToEnd, intraprocess_service)
   auto res_with_info_2_opt = client2.get_response_with_info();
   ASSERT_TRUE(res_with_info_1_opt.has_value());
   ASSERT_TRUE(res_with_info_2_opt.has_value());
-  auto res_with_info_1 = res_with_info_1_opt.value();
-  auto res_with_info_2 = res_with_info_2_opt.value();
-  auto res_1 = res_with_info_1.first;
-  auto res_2 = res_with_info_2.first;
-  auto res_info_1 = res_with_info_1.second;
-  auto res_info_2 = res_with_info_2.second;
+  auto [res_1, res_info_1] = res_with_info_1_opt.value();
+  auto [res_2, res_info_2] = res_with_info_2_opt.value();
 
   EXPECT_STREQ(res_1.c_str(), "a super response");
   EXPECT_STREQ(res_2.c_str(), "an awesome response");

--- a/email_examples/src/intra_pub_sub_wait_message_info.cpp
+++ b/email_examples/src/intra_pub_sub_wait_message_info.cpp
@@ -29,9 +29,7 @@ int main()
   pub.publish("my awesome message!");
 
   std::cout << "waiting for message on topic '" << sub.get_topic_name() << "'..." << std::endl;
-  auto message_with_info = email::wait_for_message_with_info(&sub);
-  auto message = message_with_info.first;
-  auto msg_info = message_with_info.second;
+  const auto [message, msg_info] = email::wait_for_message_with_info(&sub);
   std::cout << "got message: " << message << std::endl;
   std::cout << "message info:" << std::endl <<
     "\tsource timestamp  : " << fmt::format("{}", msg_info.source_timestamp()) << std::endl <<

--- a/email_examples/src/intra_service_client_server_wait_service_info.cpp
+++ b/email_examples/src/intra_service_client_server_wait_service_info.cpp
@@ -34,9 +34,7 @@ int main()
 
   std::cout << "waiting for request for service '" << server.get_service_name() << "'..." <<
     std::endl;
-  auto request_with_info = email::wait_for_request_with_info(&server);
-  auto request = request_with_info.first;
-  auto request_info = request_with_info.second;
+  const auto [request, request_info] = email::wait_for_request_with_info(&server);
   std::cout << "got request!" << std::endl <<
     "\tsequence number: " << request.id.sequence_number << std::endl <<
     "\trequest        : " << request.content << std::endl;
@@ -51,9 +49,7 @@ int main()
   server.send_response(request.id, response_content);
 
   std::cout << "waiting for response..." << std::endl;
-  auto response_with_info = email::wait_for_response_with_info(sequence_number, &client);
-  auto response = response_with_info.first;
-  auto resp_info = response_with_info.second;
+  const auto [response, resp_info] = email::wait_for_response_with_info(sequence_number, &client);
   std::cout << "response: " << response << std::endl;
   std::cout << "request info:" << std::endl <<
     "\tsource timestamp  : " << fmt::format("{}", resp_info.source_timestamp()) << std::endl <<

--- a/email_examples/src/service_client_wait_service_info.cpp
+++ b/email_examples/src/service_client_wait_service_info.cpp
@@ -28,14 +28,12 @@ int main()
     request_content << std::endl;
   auto sequence_number = client.send_request(request_content);
   std::cout << "waiting for response..." << std::endl;
-  auto response_with_info = email::wait_for_response_with_info(sequence_number, &client);
-  auto response = response_with_info.first;
-  auto request_info = response_with_info.second;
+  const auto [response, req_info] = email::wait_for_response_with_info(sequence_number, &client);
   std::cout << "response: " << response << std::endl;
   std::cout << "request info:" << std::endl <<
-    "\tsource timestamp  : " << fmt::format("{}", request_info.source_timestamp()) << std::endl <<
-    "\treceived timestamp: " << fmt::format("{}", request_info.received_timestamp()) << std::endl <<
-    "\tclient GID        : " << request_info.client_gid().to_string() << std::endl;
+    "\tsource timestamp  : " << fmt::format("{}", req_info.source_timestamp()) << std::endl <<
+    "\treceived timestamp: " << fmt::format("{}", req_info.received_timestamp()) << std::endl <<
+    "\tclient GID        : " << req_info.client_gid().to_string() << std::endl;
   email::shutdown();
   return 0;
 }

--- a/email_examples/src/service_server_wait_service_info.cpp
+++ b/email_examples/src/service_server_wait_service_info.cpp
@@ -26,18 +26,16 @@ int main()
   email::ServiceServer server("/my_service");
   std::cout << "waiting for request for service '" << server.get_service_name() << "'..." <<
     std::endl;
-  auto request_with_info = email::wait_for_request_with_info(&server);
-  auto request = request_with_info.first;
-  auto request_info = request_with_info.second;
+  const auto [request, req_info] = email::wait_for_request_with_info(&server);
   std::cout << "got request!" << std::endl <<
     "\tsequence number: " << request.id.sequence_number << std::endl <<
     "\trequest        : " << request.content << std::endl;
   std::cout << "request info:" << std::endl <<
-    "\tsource timestamp  : " << fmt::format("{}", request_info.source_timestamp()) <<
+    "\tsource timestamp  : " << fmt::format("{}", req_info.source_timestamp()) <<
     std::endl <<
-    "\treceived timestamp: " << fmt::format("{}", request_info.received_timestamp()) <<
+    "\treceived timestamp: " << fmt::format("{}", req_info.received_timestamp()) <<
     std::endl <<
-    "\tclient GID        : " << request_info.client_gid().to_string() << std::endl;
+    "\tclient GID        : " << req_info.client_gid().to_string() << std::endl;
   const std::string response_content = "responseeeee!";
   std::cout << "sending response: " << response_content << std::endl;
   server.send_response(request.id, response_content);

--- a/email_examples/src/sub_wait_message_info.cpp
+++ b/email_examples/src/sub_wait_message_info.cpp
@@ -23,9 +23,7 @@ int main()
   email::init();
   email::Subscription sub("/my_topic");
   std::cout << "waiting for message on topic '" << sub.get_topic_name() << "'..." << std::endl;
-  auto message_with_info = email::wait_for_message_with_info(&sub);
-  auto message = message_with_info.first;
-  auto msg_info = message_with_info.second;
+  const auto [message, msg_info] = email::wait_for_message_with_info(&sub);
   std::cout << "got message: " << message << std::endl;
   std::cout << "message info:" << std::endl <<
     "\tsource timestamp  : " << fmt::format("{}", msg_info.source_timestamp()) << std::endl <<

--- a/rmw_email_cpp/src/rmw_request.cpp
+++ b/rmw_email_cpp/src/rmw_request.cpp
@@ -84,9 +84,7 @@ extern "C" rmw_ret_t rmw_take_request(
     return ret;
   }
   *taken = true;
-  auto request_with_info = request_with_info_opt.value();
-  const struct email::ServiceRequest request = request_with_info.first;
-  const email::ServiceInfo info = request_with_info.second;
+  const auto [request, info] = request_with_info_opt.value();
 
   // Convert YAML string back to request
   rcutils_allocator_t allocator = rcutils_get_default_allocator();

--- a/rmw_email_cpp/src/rmw_response.cpp
+++ b/rmw_email_cpp/src/rmw_response.cpp
@@ -90,9 +90,7 @@ extern "C" rmw_ret_t rmw_take_response(
     return ret;
   }
   *taken = true;
-  auto response_with_info = response_with_info_opt.value();
-  const std::string response = response_with_info.first;
-  const email::ServiceInfo info = response_with_info.second;
+  const auto [response, info] = response_with_info_opt.value();
 
   // Convert YAML string back to response
   rcutils_allocator_t allocator = rcutils_get_default_allocator();

--- a/rmw_email_cpp/src/take.cpp
+++ b/rmw_email_cpp/src/take.cpp
@@ -57,9 +57,7 @@ rmw_ret_t rmw_take(
     *taken = false;
   } else {
     *taken = true;
-    auto msg_with_info = msg_with_info_opt.value();
-    const std::string & msg_yaml = msg_with_info.first;
-    const email::MessageInfo msg_info = msg_with_info.second;
+    const auto & [msg_yaml, msg_info] = msg_with_info_opt.value();
 
     // Convert YAML string back to message
     rcutils_allocator_t allocator = rcutils_get_default_allocator();


### PR DESCRIPTION
We use a lot of `std::pair<>`, so this simplifies the unpacking code. See: https://en.cppreference.com/w/cpp/language/structured_binding.