### PR TITLE
Replace rcpputils::fs with std::filesystem where applicable

### DIFF
--- a/email/include/email/log.hpp
+++ b/email/include/email/log.hpp
@@ -15,11 +15,11 @@
 #ifndef EMAIL__LOG_HPP_
 #define EMAIL__LOG_HPP_
 
+#include <filesystem>
 #include <memory>
 #include <stdexcept>
 #include <string>
 
-#include "rcpputils/filesystem_helper.hpp"
 #include "spdlog/spdlog.h"
 #include "spdlog/fmt/ostr.h"
 #include "yaml-cpp/yaml.h"
@@ -118,12 +118,12 @@ shutdown();
 }  // namespace log
 }  // namespace email
 
-/// Formatting for rcpputils::fs::path objects.
+/// Formatting for std::filesystem::path objects.
 template<>
-struct fmt::formatter<rcpputils::fs::path>: formatter<string_view>
+struct fmt::formatter<std::filesystem::path>: formatter<string_view>
 {
   template<typename FormatContext>
-  auto format(const rcpputils::fs::path & p, FormatContext & ctx)
+  auto format(const std::filesystem::path & p, FormatContext & ctx)
   {
     return formatter<string_view>::format(p.string(), ctx);
   }

--- a/email/include/email/options.hpp
+++ b/email/include/email/options.hpp
@@ -16,12 +16,12 @@
 #define EMAIL__OPTIONS_HPP_
 
 #include <chrono>
+#include <filesystem>
 #include <memory>
 #include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
 #include <regex>
 #include <string>
 
-#include "rcpputils/filesystem_helper.hpp"
 #include "yaml-cpp/yaml.h"
 
 #include "email/email/info.hpp"
@@ -139,7 +139,7 @@ public:
    */
   static
   std::optional<std::shared_ptr<Options>>
-  parse_options_file(const rcpputils::fs::path & file_path);
+  parse_options_file(const std::filesystem::path & file_path);
 
 private:
   /// Implementation for `yaml_to_options_impl` that may throw.

--- a/email/src/options.cpp
+++ b/email/src/options.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <chrono>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <optional>  // NOLINT cpplint mistakes <optional> for a C system header
@@ -20,7 +21,6 @@
 #include <string>
 #include <vector>
 
-#include "rcpputils/filesystem_helper.hpp"
 #include "rcutils/env.h"
 #include "yaml-cpp/yaml.h"
 
@@ -199,10 +199,10 @@ Options::yaml_to_options(YAML::Node node)
 }
 
 std::optional<std::shared_ptr<Options>>
-Options::parse_options_file(const rcpputils::fs::path & file_path)
+Options::parse_options_file(const std::filesystem::path & file_path)
 {
   logger()->debug("parsing options file: {}", file_path);
-  if (file_path.is_directory() || !file_path.exists()) {
+  if (std::filesystem::is_directory(file_path) || !std::filesystem::exists(file_path)) {
     logger()->debug("options file path does not exist or is not a file: {}", file_path);
     return std::nullopt;
   }
@@ -223,7 +223,7 @@ Options::parse_options_from_file()
   // First try using path from environment variable or the default value
   const std::string config_file_path = utils::get_env_var_or_default(
     Options::ENV_VAR_CONFIG_FILE,
-    (rcpputils::fs::current_path() / Options::CONFIG_FILE_DEFAULT_NAME).string());
+    (std::filesystem::current_path() / Options::CONFIG_FILE_DEFAULT_NAME).string());
 
   // Value can't be empty here because the default value is used if the env var is empty
   auto options = Options::parse_options_file(config_file_path);
@@ -231,10 +231,10 @@ Options::parse_options_from_file()
     // Try reading backup config file
     // Use file path from environment variable if defined,
     // otherwise use the default name relative to the home directory
-    const rcpputils::fs::path backup_file_path =
+    const std::filesystem::path backup_file_path =
       utils::get_env_var_or_default(
       Options::ENV_VAR_CONFIG_FILE_DEFAULT_PATH,
-      (rcpputils::fs::path(rcutils_get_home_dir()) / Options::CONFIG_FILE_DEFAULT_NAME).string());
+      (std::filesystem::path(rcutils_get_home_dir()) / Options::CONFIG_FILE_DEFAULT_NAME).string());
     logger()->debug("trying backup config file path: {}", backup_file_path);
     options = Options::parse_options_file(backup_file_path);
     if (!options) {

--- a/email/test/test_context.cpp
+++ b/email/test/test_context.cpp
@@ -14,18 +14,18 @@
 
 #include <gtest/gtest.h>
 
+#include <filesystem>
 #include <fstream>
 #include <string>
 
 #include "email/context.hpp"
 #include "email/init.hpp"
-#include "rcpputils/filesystem_helper.hpp"
 #include "rcutils/env.h"
 
 TEST(TestContext, init_fail)
 {
-  rcpputils::fs::path file =
-    rcpputils::fs::temp_directory_path() / "TestContext-init_fail.email.yml";
+  std::filesystem::path file =
+    std::filesystem::temp_directory_path() / "TestContext-init_fail.email.yml";
   ASSERT_TRUE(rcutils_set_env("EMAIL_CONFIG_FILE", file.string().c_str()));
   ASSERT_TRUE(rcutils_set_env("EMAIL_CONFIG_FILE_DEFAULT_PATH", file.string().c_str()));
 
@@ -46,8 +46,8 @@ TEST(TestContext, init_fail)
 
 TEST(TestContext, init_shutdown)
 {
-  rcpputils::fs::path config_file =
-    rcpputils::fs::temp_directory_path() / "TestContext-shutdown.email.yml";
+  std::filesystem::path config_file =
+    std::filesystem::temp_directory_path() / "TestContext-shutdown.email.yml";
   ASSERT_TRUE(rcutils_set_env("EMAIL_CONFIG_FILE", config_file.string().c_str()));
   std::ofstream config_file_stream;
   config_file_stream = std::ofstream(config_file.string().c_str());
@@ -71,6 +71,6 @@ email:
   ASSERT_TRUE(email::shutdown());
   ASSERT_FALSE(email::shutdown());
 
-  EXPECT_TRUE(rcpputils::fs::remove(config_file));
+  EXPECT_TRUE(std::filesystem::remove(config_file));
   ASSERT_TRUE(rcutils_set_env("EMAIL_CONFIG_FILE", NULL));
 }

--- a/email/test/test_end_to_end.cpp
+++ b/email/test/test_end_to_end.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <set>
@@ -21,7 +22,6 @@
 
 #include "email/context.hpp"
 #include "email/email.hpp"
-#include "rcpputils/filesystem_helper.hpp"
 #include "rcutils/env.h"
 #include "rcutils/testing/fault_injection.h"
 
@@ -31,7 +31,7 @@ public:
   void SetUp()
   {
     config_file =
-      rcpputils::fs::temp_directory_path() / "TestEndToEnd.email.yml";
+      std::filesystem::temp_directory_path() / "TestEndToEnd.email.yml";
     ASSERT_TRUE(rcutils_set_env("EMAIL_CONFIG_FILE", config_file.string().c_str()));
     std::ofstream config_file_stream;
     config_file_stream = std::ofstream(config_file.string().c_str());
@@ -57,11 +57,11 @@ email:
   {
     EXPECT_TRUE(email::shutdown());
 
-    EXPECT_TRUE(rcpputils::fs::remove(config_file));
+    EXPECT_TRUE(std::filesystem::remove(config_file));
     ASSERT_TRUE(rcutils_set_env("EMAIL_CONFIG_FILE", NULL));
   }
 
-  rcpputils::fs::path config_file;
+  std::filesystem::path config_file;
 };
 
 TEST_F(TestEndToEnd, intraprocess_init)

--- a/email/test/test_log.cpp
+++ b/email/test/test_log.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <filesystem>
 #include <memory>
 #include <string>
 
@@ -78,12 +79,12 @@ TEST(TestLog, get)
 
 TEST(TestLog, file)
 {
-  auto temp_dir = rcpputils::fs::create_temp_directory("TestLog_file");
+  auto temp_dir = rcpputils::fs::create_temporary_directory("TestLog_file");
   auto logfile_path = temp_dir / "log";
   EXPECT_TRUE(rcutils_set_env("EMAIL_LOG_FILE", logfile_path.string().c_str()));
   email::log::init_from_env();
 
   email::log::shutdown();
   EXPECT_TRUE(rcutils_set_env("EMAIL_LOG_FILE", nullptr));
-  EXPECT_TRUE(rcpputils::fs::remove_all(temp_dir));
+  EXPECT_TRUE(std::filesystem::remove_all(temp_dir));
 }

--- a/email/test/test_options.cpp
+++ b/email/test/test_options.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -39,7 +40,7 @@ public:
     email::log::shutdown();
   }
 
-  rcpputils::fs::path tmp{rcpputils::fs::temp_directory_path()};
+  std::filesystem::path tmp{std::filesystem::temp_directory_path()};
 };
 
 TEST_F(TestOptions, yaml_to_options)
@@ -154,12 +155,12 @@ TEST_F(TestOptions, yaml_to_options_intraprocess)
 
 TEST_F(TestOptions, parse_options_file)
 {
-  rcpputils::fs::path file;
+  std::filesystem::path file;
 
   // Exists, but directory
-  file = rcpputils::fs::create_temp_directory("TestOptions-parse_options_file-dir-");
+  file = rcpputils::fs::create_temporary_directory("TestOptions-parse_options_file-dir-");
   EXPECT_FALSE(email::Options::parse_options_file(file).has_value());
-  EXPECT_TRUE(rcpputils::fs::remove(file));
+  EXPECT_TRUE(std::filesystem::remove(file));
 
   // File, but doesn't exist
   file = tmp / "TestOptions-parse_options_file-not-created";
@@ -173,19 +174,19 @@ TEST_F(TestOptions, parse_options_file)
   file_stream << "DIPSY" << std::endl;
   file_stream.close();
   EXPECT_FALSE(email::Options::parse_options_file(file).has_value());
-  EXPECT_TRUE(rcpputils::fs::remove(file));
+  EXPECT_TRUE(std::filesystem::remove(file));
 
   file_stream = std::ofstream(file.string().c_str());
   file_stream << "{DIPSY" << std::endl;
   file_stream.close();
   EXPECT_FALSE(email::Options::parse_options_file(file).has_value());
-  EXPECT_TRUE(rcpputils::fs::remove(file));
+  EXPECT_TRUE(std::filesystem::remove(file));
 }
 
 TEST_F(TestOptions, parse_options_from_file)
 {
   // Good file
-  rcpputils::fs::path file = tmp / "TestOptions-parse_options_from_file.email.yml";
+  std::filesystem::path file = tmp / "TestOptions-parse_options_from_file.email.yml";
   ASSERT_TRUE(rcutils_set_env("EMAIL_CONFIG_FILE", file.string().c_str()));
   std::ofstream file_stream;
   file_stream = std::ofstream(file.string().c_str());
@@ -216,7 +217,7 @@ email:
   EXPECT_STREQ("to@email.com", options_val->get_recipients().value()->to[0].c_str());
   EXPECT_FALSE(options_val->intraprocess());
 
-  EXPECT_TRUE(rcpputils::fs::remove(file));
+  EXPECT_TRUE(std::filesystem::remove(file));
   ASSERT_TRUE(rcutils_set_env("EMAIL_CONFIG_FILE", NULL));
 
   // Bad default file
@@ -228,14 +229,14 @@ email:
   options = email::Options::parse_options_from_file();
   EXPECT_FALSE(options.has_value());
 
-  EXPECT_TRUE(rcpputils::fs::remove(file));
+  EXPECT_TRUE(std::filesystem::remove(file));
   ASSERT_TRUE(rcutils_set_env("EMAIL_CONFIG_FILE_DEFAULT_PATH", NULL));
 }
 
 TEST_F(TestOptions, parse_options_from_file_intraprocess)
 {
   // Good file
-  rcpputils::fs::path file = tmp / "TestOptions-parse_options_from_file_intraprocess.email.yml";
+  std::filesystem::path file = tmp / "TestOptions-parse_options_from_file_intraprocess.email.yml";
   ASSERT_TRUE(rcutils_set_env("EMAIL_CONFIG_FILE", file.string().c_str()));
   std::ofstream file_stream;
   file_stream = std::ofstream(file.string().c_str());
@@ -257,7 +258,7 @@ email:
   EXPECT_FALSE(options_val->get_recipients().has_value());
   EXPECT_FALSE(options_val->polling_period().has_value());
 
-  EXPECT_TRUE(rcpputils::fs::remove(file));
+  EXPECT_TRUE(std::filesystem::remove(file));
   ASSERT_TRUE(rcutils_set_env("EMAIL_CONFIG_FILE", NULL));
 }
 


### PR DESCRIPTION
Use std::filesystem for everything except rcpputils::fs::create_temporary_directory.