### PR TITLE
Fix design docs generation

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,5 +1,6 @@
 name: Documentation
 on:
+  pull_request:
   push:
     branches:
       - rolling
@@ -28,7 +29,7 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v4
       with:
-        ref: rolling
+        ref: christophebedard/fix-design-docs-gen
         fetch-depth: 0
         path: rmw_email
     - name: Gen API docs
@@ -39,17 +40,17 @@ jobs:
         mkdir -p pandoc/email/ && cd pandoc/email/
         sed -i '/christophebedard.com/d' ../../rmw_email/email/doc/design.md
         pandoc ../../rmw_email/email/doc/design.md --filter pandoc-plantuml > index.html
-    - name: Copy docs to gh-pages
-      run: |
-        rm -rf gh-pages/api/
-        mv docs_output/ gh-pages/api/
-        rm -rf gh-pages/design/
-        mv -T pandoc/ gh-pages/design/
-    - name: Commit and push to gh-pages branch
-      run: |
-        cd gh-pages
-        git config --global user.email "3717345+christophebedard@users.noreply.github.com"
-        git config --global user.name "Christophe Bedard [bot]"
-        git add .
-        git commit -m "Update docs"
-        git push origin gh-pages
+    # - name: Copy docs to gh-pages
+    #   run: |
+    #     rm -rf gh-pages/api/
+    #     mv docs_output/ gh-pages/api/
+    #     rm -rf gh-pages/design/
+    #     mv -T pandoc/ gh-pages/design/
+    # - name: Commit and push to gh-pages branch
+    #   run: |
+    #     cd gh-pages
+    #     git config --global user.email "3717345+christophebedard@users.noreply.github.com"
+    #     git config --global user.name "Christophe Bedard [bot]"
+    #     git add .
+    #     git commit -m "Update docs"
+    #     git push origin gh-pages

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,6 +1,5 @@
 name: Documentation
 on:
-  pull_request:
   push:
     branches:
       - rolling
@@ -29,7 +28,7 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v4
       with:
-        ref: christophebedard/fix-design-docs-gen
+        ref: rolling
         fetch-depth: 0
         path: rmw_email
     - name: Gen API docs
@@ -40,17 +39,17 @@ jobs:
         mkdir -p pandoc/email/ && cd pandoc/email/
         sed -i '/christophebedard.com/d' ../../rmw_email/email/doc/design.md
         pandoc ../../rmw_email/email/doc/design.md --filter pandoc-plantuml > index.html
-    # - name: Copy docs to gh-pages
-    #   run: |
-    #     rm -rf gh-pages/api/
-    #     mv docs_output/ gh-pages/api/
-    #     rm -rf gh-pages/design/
-    #     mv -T pandoc/ gh-pages/design/
-    # - name: Commit and push to gh-pages branch
-    #   run: |
-    #     cd gh-pages
-    #     git config --global user.email "3717345+christophebedard@users.noreply.github.com"
-    #     git config --global user.name "Christophe Bedard [bot]"
-    #     git add .
-    #     git commit -m "Update docs"
-    #     git push origin gh-pages
+    - name: Copy docs to gh-pages
+      run: |
+        rm -rf gh-pages/api/
+        mv docs_output/ gh-pages/api/
+        rm -rf gh-pages/design/
+        mv -T pandoc/ gh-pages/design/
+    - name: Commit and push to gh-pages branch
+      run: |
+        cd gh-pages
+        git config --global user.email "3717345+christophebedard@users.noreply.github.com"
+        git config --global user.name "Christophe Bedard [bot]"
+        git add .
+        git commit -m "Update docs"
+        git push origin gh-pages

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,11 +14,8 @@ jobs:
         python-version: '3.10'
     - name: Install dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install -y doxygen pandoc plantuml
-        pip3 install pandoc-plantuml-filter
-        wget https://github.com/plantuml/plantuml/releases/download/v1.2023.5/plantuml-1.2023.5.jar
-        chmod +x plantuml-*.jar
+        sudo apt update
+        sudo apt install -y doxygen pandoc plantuml pandoc-plantuml-filter
     - name: Install rosdoc2
       run: |
         pip3 install -U git+https://github.com/ros-infrastructure/rosdoc2.git@main
@@ -41,7 +38,7 @@ jobs:
       run: |
         mkdir -p pandoc/email/ && cd pandoc/email/
         sed -i '/christophebedard.com/d' ../../rmw_email/email/doc/design.md
-        PLANTUML_BIN="$(pwd)/../../plantuml-1.2023.5.jar" pandoc ../../rmw_email/email/doc/design.md --filter pandoc-plantuml > index.html
+        pandoc ../../rmw_email/email/doc/design.md --filter pandoc-plantuml > index.html
     - name: Copy docs to gh-pages
       run: |
         rm -rf gh-pages/api/

--- a/email/doc/design.md
+++ b/email/doc/design.md
@@ -402,7 +402,7 @@ ServiceClient "0..*" o-- WaitSet
 ServiceServer "0..*" o-- WaitSet
 GuardCondition "0..*" o-- "0..1" WaitSet
 
-class wait. {
+class wait {
    .. Subscription ..
    +wait_for_message(Subscription * subscription, milliseconds timeout): string
    +wait_for_message_with_info(Subscription * subscription, milliseconds timeout): pair<string, MessageInfo>


### PR DESCRIPTION
There's an error in the "Gen design docs" step:

```
Created directory plantuml-images
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.16/x64/bin/pandoc-plantuml", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/pandoc_plantuml_filter.py", line 85, in main
    toJSONFilter(plantuml)
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/pandocfilters.py", line [14](https://github.com/christophebedard/rmw_email/actions/runs/14149184850/job/39640236147#step:8:15)8, in toJSONFilter
    toJSONFilters([action])
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/pandocfilters.py", line 182, in toJSONFilters
    sys.stdout.write(applyJSONFilters(actions, source, format))
  File "/opt/hostedtoolcache/Python/3.10.[16](https://github.com/christophebedard/rmw_email/actions/runs/14149184850/job/39640236147#step:8:17)/x64/lib/python3.10/site-packages/pandocfilters.py", line 213, in applyJSONFilters
    altered = walk(altered, action, format, meta)
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/pandocfilters.py", line 141, in walk
    return {k: walk(v, action, format, meta) for k, v in x.items()}
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/pandocfilters.py", line 141, in <dictcomp>
    return {k: walk(v, action, format, meta) for k, v in x.items()}
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/pandocfilters.py", line 128, in walk
    res = action(item['t'],
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/pandoc_plantuml_filter.py", line 69, in plantuml
    subprocess.check_call(PLANTUML_BIN.split() + ["-t" + filetype, src])
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/subprocess.py", line 364, in check_call
    retcode = call(*popenargs, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/subprocess.py", line 345, in call
    with Popen(*popenargs, **kwargs) as p:
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/subprocess.py", line 971, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/subprocess.py", line [18](https://github.com/christophebedard/rmw_email/actions/runs/14149184850/job/39640236147#step:8:19)63, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
OSError: [Errno 8] Exec format error: '/home/runner/work/rmw_email/rmw_email/pandoc/email/../../plantuml-1.[20](https://github.com/christophebedard/rmw_email/actions/runs/14149184850/job/39640236147#step:8:21)23.5.jar'
Error running filter pandoc-plantuml:
```

Just use the system plantuml and pandoc-plantuml-filter, which seems to work.

Commit f8e996655d7d63095ea8da5d1b3acc63709a722d makes the docs generation run on this PR (without actually pushing the docs), which confirms that it works.