### PR TITLE
Use ament_cmake buildtool instead of ament_cmake_ros

### DIFF
--- a/email/CMakeLists.txt
+++ b/email/CMakeLists.txt
@@ -12,7 +12,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   add_compile_options(/W4)
 endif()
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(spdlog_vendor REQUIRED)
@@ -118,7 +118,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 )
 ament_export_include_directories(include)
 ament_export_dependencies(
-  ament_cmake_ros
   rcpputils
   rcutils
   spdlog_vendor

--- a/email/package.xml
+++ b/email/package.xml
@@ -11,7 +11,7 @@
   <url type="bugtracker">https://github.com/christophebedard/rmw_email/issues</url>
   <author email="bedard.christophe@gmail.com">Christophe Bedard</author>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>spdlog_vendor</build_depend>
   <build_depend>spdlog</build_depend>

--- a/email_examples/CMakeLists.txt
+++ b/email_examples/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 include(cmake/add_example.cmake)
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
 find_package(email REQUIRED)
 
 # Examples & executables for testing the lib

--- a/email_examples/package.xml
+++ b/email_examples/package.xml
@@ -8,7 +8,7 @@
   <license>Apache License 2.0</license>
   <author email="bedard.christophe@gmail.com">Christophe Bedard</author>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>email</depend>
 

--- a/rmw_email_cpp/CMakeLists.txt
+++ b/rmw_email_cpp/CMakeLists.txt
@@ -11,7 +11,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   add_compile_options(/W4)
 endif()
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
 
 # Try to find 'email' and skip building this if not found
 find_package(email QUIET)

--- a/rmw_email_cpp/package.xml
+++ b/rmw_email_cpp/package.xml
@@ -11,7 +11,7 @@
   <url type="bugtracker">https://github.com/christophebedard/rmw_email/issues</url>
   <author email="bedard.christophe@gmail.com">Christophe Bedard</author>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>dynmsg</depend>
   <depend>email</depend>


### PR DESCRIPTION
`ament_cmake_ros` itself (buildtool) depends on `ament_cmake` and adds `ament_add_ros_*()` CMake functions, which we don't need.

This fixes the build-time topological ordering issue from https://github.com/christophebedard/rmw_email/pull/338#issuecomment-3146817506. I believe it is due to changes to `ament_cmake_ros`, possibly related to https://github.com/ros2/ament_cmake_ros/pull/20.