### PR TITLE
Explicitly provide rosdoc2 output dir

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -36,7 +36,7 @@ jobs:
         path: rmw_email
     - name: Gen API docs
       run: |
-        rosdoc2 build --package-path rmw_email/email/
+        rosdoc2 build --output-directory docs_output --package-path rmw_email/email/
     - name: Gen design docs
       run: |
         mkdir -p pandoc/email/ && cd pandoc/email/


### PR DESCRIPTION
So that it's easier to figure out where the `docs_output` directory is coming from below, in the "Copy docs to gh-pages" step.