### PR TITLE
Add implementations for new rmw functions

### DIFF
--- a/rmw_email_cpp/CMakeLists.txt
+++ b/rmw_email_cpp/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(${PROJECT_NAME}
 
   src/rmw_client.cpp
   src/rmw_event.cpp
+  src/rmw_features.cpp
   src/rmw_gid.cpp
   src/rmw_get_service_names_and_types.cpp
   src/rmw_get_topic_endpoint_info.cpp

--- a/rmw_email_cpp/src/rmw_client.cpp
+++ b/rmw_email_cpp/src/rmw_client.cpp
@@ -148,3 +148,46 @@ extern "C" rmw_ret_t rmw_count_clients(
   *count = 1u;
   return RMW_RET_OK;
 }
+
+extern "C" rmw_ret_t rmw_client_set_on_new_response_callback(
+  rmw_client_t * client,
+  rmw_event_callback_t callback,
+  const void * user_data)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
+  static_cast<void>(callback);
+  static_cast<void>(user_data);
+  return RMW_RET_UNSUPPORTED;
+}
+
+extern "C" rmw_ret_t rmw_client_request_publisher_get_actual_qos(
+  const rmw_client_t * client,
+  rmw_qos_profile_t * qos)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    client,
+    client->implementation_identifier,
+    rmw_email_cpp::identifier,
+    return RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(qos, RMW_RET_INVALID_ARGUMENT);
+
+  // TODO(christophebedard) figure out
+  return RMW_RET_OK;
+}
+
+extern "C" rmw_ret_t rmw_client_response_subscription_get_actual_qos(
+  const rmw_client_t * client,
+  rmw_qos_profile_t * qos)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    client,
+    client->implementation_identifier,
+    rmw_email_cpp::identifier,
+    return RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(qos, RMW_RET_INVALID_ARGUMENT);
+
+  // TODO(christophebedard) figure out
+  return RMW_RET_OK;
+}

--- a/rmw_email_cpp/src/rmw_event.cpp
+++ b/rmw_email_cpp/src/rmw_event.cpp
@@ -96,3 +96,21 @@ extern "C" rmw_ret_t rmw_take_event(
   // Do nothing, should not be called because there shouldn't be any events
   return RMW_RET_OK;
 }
+
+extern "C" bool rmw_event_type_is_supported(rmw_event_type_t rmw_event_type)
+{
+  static_cast<void>(rmw_event_type);
+  // Unsupported
+  return false;
+}
+
+extern "C" rmw_ret_t rmw_event_set_callback(
+  rmw_event_t * event,
+  rmw_event_callback_t callback,
+  const void * user_data)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(event, RMW_RET_INVALID_ARGUMENT);
+  static_cast<void>(callback);
+  static_cast<void>(user_data);
+  return RMW_RET_UNSUPPORTED;
+}

--- a/rmw_email_cpp/src/rmw_features.cpp
+++ b/rmw_email_cpp/src/rmw_features.cpp
@@ -1,0 +1,31 @@
+// Copyright 2025 Christophe Bedard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rmw/features.h"
+
+extern "C" bool rmw_feature_supported(rmw_feature_t feature)
+{
+  switch (feature) {
+    case RMW_FEATURE_MESSAGE_INFO_PUBLICATION_SEQUENCE_NUMBER:
+      return false;
+    case RMW_FEATURE_MESSAGE_INFO_RECEPTION_SEQUENCE_NUMBER:
+      return false;
+    case RMW_MIDDLEWARE_SUPPORTS_TYPE_DISCOVERY:
+      return false;
+    case RMW_MIDDLEWARE_CAN_TAKE_DYNAMIC_MESSAGE:
+      return false;
+    default:
+      return false;
+  }
+}

--- a/rmw_email_cpp/src/rmw_gid.cpp
+++ b/rmw_email_cpp/src/rmw_gid.cpp
@@ -38,6 +38,23 @@ extern "C" rmw_ret_t rmw_get_gid_for_publisher(
   return RMW_RET_OK;
 }
 
+extern "C" rmw_ret_t rmw_get_gid_for_client(const rmw_client_t * client, rmw_gid_t * gid)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    client,
+    client->implementation_identifier,
+    rmw_email_cpp::identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(gid, RMW_RET_INVALID_ARGUMENT);
+
+  auto rmw_email_client = static_cast<rmw_email_client_t *>(client->data);
+  email::ServiceClient * email_client = rmw_email_client->email_client;
+  rmw_gid_t rmw_client_gid = rmw_email_cpp::convert_gid(email_client->get_gid());
+  rmw_email_cpp::copy_gids(gid, &rmw_client_gid);
+  return RMW_RET_OK;
+}
+
 extern "C" rmw_ret_t rmw_compare_gids_equal(
   const rmw_gid_t * gid1,
   const rmw_gid_t * gid2,

--- a/rmw_email_cpp/src/rmw_service.cpp
+++ b/rmw_email_cpp/src/rmw_service.cpp
@@ -175,3 +175,46 @@ extern "C" rmw_ret_t rmw_count_services(
   *count = 1u;
   return RMW_RET_OK;
 }
+
+extern "C" rmw_ret_t rmw_service_set_on_new_request_callback(
+  rmw_service_t * service,
+  rmw_event_callback_t callback,
+  const void * user_data)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(service, RMW_RET_INVALID_ARGUMENT);
+  static_cast<void>(callback);
+  static_cast<void>(user_data);
+  return RMW_RET_UNSUPPORTED;
+}
+
+extern "C" rmw_ret_t rmw_service_request_subscription_get_actual_qos(
+  const rmw_service_t * service,
+  rmw_qos_profile_t * qos)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(service, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    service,
+    service->implementation_identifier,
+    rmw_email_cpp::identifier,
+    return RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(qos, RMW_RET_INVALID_ARGUMENT);
+
+  // TODO(christophebedard) figure out
+  return RMW_RET_OK;
+}
+
+extern "C" rmw_ret_t rmw_service_response_publisher_get_actual_qos(
+  const rmw_service_t * service,
+  rmw_qos_profile_t * qos)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(service, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    service,
+    service->implementation_identifier,
+    rmw_email_cpp::identifier,
+    return RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(qos, RMW_RET_INVALID_ARGUMENT);
+
+  // TODO(christophebedard) figure out
+  return RMW_RET_OK;
+}

--- a/rmw_email_cpp/src/rmw_subscription.cpp
+++ b/rmw_email_cpp/src/rmw_subscription.cpp
@@ -215,3 +215,44 @@ extern "C" rmw_ret_t rmw_count_subscribers(
   *count = 1u;
   return RMW_RET_OK;
 }
+
+extern "C" rmw_ret_t rmw_subscription_set_on_new_message_callback(
+  rmw_subscription_t * subscription,
+  rmw_event_callback_t callback,
+  const void * user_data)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(subscription, RMW_RET_INVALID_ARGUMENT);
+  static_cast<void>(callback);
+  static_cast<void>(user_data);
+  return RMW_RET_UNSUPPORTED;
+}
+
+extern "C" rmw_ret_t rmw_subscription_set_content_filter(
+  rmw_subscription_t * subscription,
+  const rmw_subscription_content_filter_options_t * options)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(subscription, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    subscription,
+    subscription->implementation_identifier,
+    rmw_email_cpp::identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(options, RMW_RET_INVALID_ARGUMENT);
+  return RMW_RET_UNSUPPORTED;
+}
+
+extern "C" rmw_ret_t rmw_subscription_get_content_filter(
+  const rmw_subscription_t * subscription,
+  rcutils_allocator_t * allocator,
+  rmw_subscription_content_filter_options_t * options)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(subscription, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    subscription,
+    subscription->implementation_identifier,
+    rmw_email_cpp::identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(allocator, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(options, RMW_RET_INVALID_ARGUMENT);
+  return RMW_RET_UNSUPPORTED;
+}


### PR DESCRIPTION
Similar to #343. This adds implementations for some new `rmw` functions:

1. Content-filtered topics: https://github.com/ros2/rmw/pull/302
    1. `rmw_subscription_set_content_filter()`
    2. `rmw_subscription_get_content_filter()`
2. Event types: https://github.com/ros2/rmw/pull/395
    1. `rmw_event_type_is_supported()`
3. Client GID: https://github.com/ros2/rmw/pull/327
    1. `rmw_get_gid_for_client()`
4. Client & service actual QoS: https://github.com/ros2/rmw/pull/314
    1. `rmw_client_request_publisher_get_actual_qos()`
    2. `rmw_client_response_subscription_get_actual_qos()`
    3. `rmw_service_request_subscription_get_actual_qos()`
    4. `rmw_service_response_publisher_get_actual_qos()`
5. Event callbacks: https://github.com/ros2/rmw/pull/286
    1. `rmw_subscription_set_on_new_message_callback()`
    2. `rmw_service_set_on_new_request_callback()`
    3. `rmw_client_set_on_new_response_callback()`
    4. `rmw_event_set_callback()`
6. Feature support: https://github.com/ros2/rmw/pull/318
    1. `rmw_feature_supported()`