### PR TITLE
Use more unique name for email's root logger

### DIFF
--- a/email/src/context.cpp
+++ b/email/src/context.cpp
@@ -101,7 +101,7 @@ Context::init_common()
 {
   is_valid_ = true;
   log::init_from_env();
-  spdlog::get("root")->debug("logging initialized");
+  spdlog::get("root_email")->debug("logging initialized");
   logger_ = log::create("Context");
 
   logger_->debug("intraprocess: {}", options_->intraprocess());

--- a/email/src/log.cpp
+++ b/email/src/log.cpp
@@ -140,7 +140,7 @@ init(const Level & level)
     sinks.push_back(sink_file);
   }
 
-  root_logger = std::make_shared<spdlog::logger>("root", sinks.begin(), sinks.end());
+  root_logger = std::make_shared<spdlog::logger>("root_email", sinks.begin(), sinks.end());
   root_logger->set_level(spdlog::level::debug);
   spdlog::register_logger(root_logger);
   root_logger->flush_on(spdlog::level::warn);


### PR DESCRIPTION
Running a ROS 2 application with `rmw_email_cpp` currently results in an exception during `email` logging initialization:

```console
$ RMW_IMPLEMENTATION=rmw_email_cpp ros2 run demo_nodes_cpp talker
root logger already exists!
terminate called after throwing an instance of 'spdlog::spdlog_ex'
  what():  logger with name 'root' already exists
Aborted
```

This specifically happens when the root logger is registered: https://github.com/christophebedard/rmw_email/blob/4921f133d2b31c53ac8eaaf19eb374bffed369bc/email/src/log.cpp#L143-L145

It turns out that `rcl_logging_spdlog` also has a logger named `"root"`, but it wasn't registered with `spdlog` until https://github.com/ros2/rcl_logging/pull/95, see  https://github.com/ros2/rcl_logging/commit/57942c6ffa745f3b141f5cdf615080d6eafac9cc. It gets registered first, so `email` can't register a logger with the same name.

Since these should be separate (`rcl_logging` vs `email`), just rename the root logger for `email` to `"root_email"`.