### PR TITLE
Fix doxygen tag

### DIFF
--- a/email/include/email/curl/executor.hpp
+++ b/email/include/email/curl/executor.hpp
@@ -40,7 +40,7 @@ public:
 
   /// Get validity status of the executor.
   /**
-   * \param true if valid, false otherwise
+   * \return true if valid, false otherwise
    */
   EMAIL_PUBLIC
   bool


### PR DESCRIPTION
Resolve this warning during API docs generation:

```
/home/runner/work/rmw_email/rmw_email/rmw_email/email/include/email/curl/executor.hpp:43: warning: email::CurlExecutor::is_valid has @param documentation sections but no arguments
```