### PR TITLE
Use libcurl directly instead of vendor pkg

### DIFF
--- a/email/CMakeLists.txt
+++ b/email/CMakeLists.txt
@@ -20,16 +20,7 @@ find_package(spdlog_vendor REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
 find_package(yaml-cpp REQUIRED)
-
-set(CURL_USE_VENDOR TRUE)
-# TODO(christophebedard) switch to using system curl when possible,
-# but for now using the vendor package makes it easier for Windows
-#find_package(CURL)
-if(CURL_USE_VENDOR OR NOT CURL_FOUND)
-  message(STATUS "using libcurl_vendor")
-  find_package(libcurl_vendor REQUIRED)
-  set(CURL_USE_VENDOR TRUE)
-endif()
+find_package(CURL REQUIRED)
 message(STATUS "Found CURL version: ${CURL_VERSION_STRING}")
 message(STATUS "Using CURL include dir(s): ${CURL_INCLUDE_DIRS}")
 message(STATUS "Using CURL lib(s): ${CURL_LIBRARIES}")
@@ -90,7 +81,7 @@ add_library(${PROJECT_NAME} SHARED
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
-  $<IF:$<BOOL:${CURL_USE_VENDOR}>,CURL::libcurl,${CURL_LIBRARIES}>
+  CURL::libcurl
   $<IF:$<BOOL:${EMAIL_HAS_LTTNG_TRACING}>,${LTTNG_LIBRARIES},>
 )
 target_link_libraries(${PROJECT_NAME} PUBLIC
@@ -120,11 +111,7 @@ ament_export_dependencies(
 )
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_libraries(${PROJECT_NAME})
-if(CURL_USE_VENDOR)
-  ament_export_dependencies(libcurl_vendor)
-else()
-  ament_export_libraries(${CURL_LIBRARIES})
-endif()
+ament_export_libraries(${CURL_LIBRARIES})
 
 install(
   DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ ${CMAKE_CURRENT_BINARY_DIR}/include/

--- a/email/QUALITY_DECLARATION.md
+++ b/email/QUALITY_DECLARATION.md
@@ -169,7 +169,7 @@ It is **Quality Level 1**, see its [Quality Declaration document](https://github
 
 #### `libcurl`
 
-The `libcurl` library, possibly through the `libcurl_vendor` package, provides a C API for multiprotocol file transfer.
+The `libcurl` library provides a C API for multiprotocol file transfer.
 
 It currently has no quality declaration.
 

--- a/email/package.xml
+++ b/email/package.xml
@@ -17,8 +17,7 @@
   <build_depend>spdlog_vendor</build_depend>
   <build_depend>spdlog</build_depend>
 
-  <!-- Only actually used if libcurl isn't found on the system -->
-  <depend>libcurl_vendor</depend>
+  <depend>libcurl-dev</depend>
   <depend>rcpputils</depend>
   <depend>rcutils</depend>
   <depend>yaml_cpp_vendor</depend>


### PR DESCRIPTION
The vendor package was recently removed, see:

* https://github.com/ros2/ros2/issues/1729
* https://github.com/ros/resource_retriever/pull/116