### PR TITLE
Rename validate_type_support_* to get_concrete_type_support_*

### DIFF
--- a/rmw_email_cpp/include/rmw_email_cpp/type_support.hpp
+++ b/rmw_email_cpp/include/rmw_email_cpp/type_support.hpp
@@ -21,10 +21,10 @@
 namespace rmw_email_cpp
 {
 
-const rosidl_message_type_support_t * validate_type_support_message(
+const rosidl_message_type_support_t * get_concrete_type_support_message(
   const rosidl_message_type_support_t * type_support);
 
-const rosidl_service_type_support_t * validate_type_support_service(
+const rosidl_service_type_support_t * get_concrete_type_support_service(
   const rosidl_service_type_support_t * type_support);
 
 }  // namespace rmw_email_cpp

--- a/rmw_email_cpp/src/rmw_client.cpp
+++ b/rmw_email_cpp/src/rmw_client.cpp
@@ -49,10 +49,10 @@ extern "C" rmw_client_t * rmw_create_client(
     return nullptr;
   }
 
-  // Validate type support
-  const rosidl_service_type_support_t * valid_type_support =
-    rmw_email_cpp::validate_type_support_service(type_support);
-  if (nullptr == valid_type_support) {
+  // Get type support
+  const rosidl_service_type_support_t * concrete_type_support =
+    rmw_email_cpp::get_concrete_type_support_service(type_support);
+  if (nullptr == concrete_type_support) {
     return nullptr;
   }
 
@@ -76,7 +76,7 @@ extern "C" rmw_client_t * rmw_create_client(
       delete rmw_email_client;
     });
   rmw_email_client->email_client = email_client;
-  rmw_email_client->type_supports = *valid_type_support;
+  rmw_email_client->type_supports = *concrete_type_support;
 
   rmw_client_t * rmw_client = rmw_client_allocate();
   RET_NULL_X(rmw_client, return nullptr);

--- a/rmw_email_cpp/src/rmw_publisher.cpp
+++ b/rmw_email_cpp/src/rmw_publisher.cpp
@@ -130,10 +130,10 @@ extern "C" rmw_publisher_t * rmw_create_publisher(
     return nullptr;
   }
 
-  // Validate type support
-  const rosidl_message_type_support_t * valid_type_support =
-    rmw_email_cpp::validate_type_support_message(type_supports);
-  if (nullptr == valid_type_support) {
+  // Get type support
+  const rosidl_message_type_support_t * concrete_type_support =
+    rmw_email_cpp::get_concrete_type_support_message(type_supports);
+  if (nullptr == concrete_type_support) {
     return nullptr;
   }
 
@@ -142,7 +142,7 @@ extern "C" rmw_publisher_t * rmw_create_publisher(
     return nullptr;
   }
 
-  return _create_publisher(topic_name, publisher_options, valid_type_support);
+  return _create_publisher(topic_name, publisher_options, concrete_type_support);
 }
 
 extern "C" rmw_ret_t rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)

--- a/rmw_email_cpp/src/rmw_service.cpp
+++ b/rmw_email_cpp/src/rmw_service.cpp
@@ -49,10 +49,10 @@ extern "C" rmw_service_t * rmw_create_service(
     return nullptr;
   }
 
-  // Validate type support
-  const rosidl_service_type_support_t * valid_type_support =
-    rmw_email_cpp::validate_type_support_service(type_support);
-  if (nullptr == valid_type_support) {
+  // Get type support
+  const rosidl_service_type_support_t * concrete_type_support =
+    rmw_email_cpp::get_concrete_type_support_service(type_support);
+  if (nullptr == concrete_type_support) {
     return nullptr;
   }
 
@@ -76,7 +76,7 @@ extern "C" rmw_service_t * rmw_create_service(
       delete rmw_email_server;
     });
   rmw_email_server->email_server = email_server;
-  rmw_email_server->type_supports = *valid_type_support;
+  rmw_email_server->type_supports = *concrete_type_support;
 
   rmw_service_t * rmw_service = rmw_service_allocate();
   RET_NULL_X(rmw_service, return nullptr);

--- a/rmw_email_cpp/src/rmw_subscription.cpp
+++ b/rmw_email_cpp/src/rmw_subscription.cpp
@@ -115,10 +115,10 @@ extern "C" rmw_subscription_t * rmw_create_subscription(
     return nullptr;
   }
 
-  // Validate type support
-  const rosidl_message_type_support_t * valid_type_support =
-    rmw_email_cpp::validate_type_support_message(type_supports);
-  if (nullptr == valid_type_support) {
+  // Get type support
+  const rosidl_message_type_support_t * concrete_type_support =
+    rmw_email_cpp::get_concrete_type_support_message(type_supports);
+  if (nullptr == concrete_type_support) {
     return nullptr;
   }
 
@@ -127,7 +127,7 @@ extern "C" rmw_subscription_t * rmw_create_subscription(
     return nullptr;
   }
 
-  return _create_subscription(topic_name, subscription_options, valid_type_support);
+  return _create_subscription(topic_name, subscription_options, concrete_type_support);
 }
 
 static rmw_ret_t _destroy_subscription(rmw_subscription_t * subscription)

--- a/rmw_email_cpp/src/type_support.cpp
+++ b/rmw_email_cpp/src/type_support.cpp
@@ -26,7 +26,7 @@
 namespace rmw_email_cpp
 {
 
-const rosidl_message_type_support_t * validate_type_support_message(
+const rosidl_message_type_support_t * get_concrete_type_support_message(
   const rosidl_message_type_support_t * type_support)
 {
   const rosidl_message_type_support_t * ts = nullptr;
@@ -57,7 +57,7 @@ const rosidl_message_type_support_t * validate_type_support_message(
   return nullptr;
 }
 
-const rosidl_service_type_support_t * validate_type_support_service(
+const rosidl_service_type_support_t * get_concrete_type_support_service(
   const rosidl_service_type_support_t * type_support)
 {
   const rosidl_service_type_support_t * ts = nullptr;


### PR DESCRIPTION
These aren't just "validating" the type support, they're actually getting the concrete type support from the base type support, e.g., `rosidl_typesupport_introspection_cpp` from `rosidl_typesupport_cpp`.

I think I named these functions when I didn't quite understand this.